### PR TITLE
Customise Ghost theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ app/static/app/images/logos/BCA/EPS/*
 # Environment
 .env*
 !.env.template
-/ghost
 /node_modules
 package*.json
 /pg_backup
+/source

--- a/compose.yml
+++ b/compose.yml
@@ -9,10 +9,8 @@ services:
             - static_files:/static
             - ./data:/data
         depends_on:
-            ghost:
-                condition: service_started
-            web:
-                condition: service_healthy
+            - ghost
+            - web
 
     ghost:
         image: ghost:5.125-alpine
@@ -21,6 +19,10 @@ services:
             - "2368"
         volumes:
             - ghost_data:/var/lib/ghost/content
+            - ./ghost/default.hbs:/var/lib/ghost/content/themes/source/default.hbs
+            - ./ghost/partials/announcement-bar.hbs:/var/lib/ghost/content/themes/source/partials/announcement-bar.hbs
+            - ./ghost/partials/components/footer.hbs:/var/lib/ghost/content/themes/source/partials/components/footer.hbs
+            - ./ghost/partials/components/post-list.hbs:/var/lib/ghost/content/themes/source/partials/components/post-list.hbs
 
     web:
         build: .

--- a/ghost/default.hbs
+++ b/ghost/default.hbs
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="{{@site.locale}}">
+<head>
+
+    {{!-- Basic meta - advanced meta is output with {{ghost_head}} below --}}
+    <title>{{meta_title}}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {{!-- Preload main styles and scripts for better performance --}}
+    <link rel="preload" as="style" href="{{asset "built/screen.css"}}">
+    <link rel="preload" as="script" href="{{asset "built/source.js"}}">
+
+    {{!-- Fonts are preloaded and defined in the default template to avoid layout shift --}}
+    {{> "typography/fonts"}}
+
+    {{!-- Theme assets - use the {{asset}} helper to reference styles & scripts, this will take care of caching and cache-busting automatically --}}
+    <link rel="stylesheet" type="text/css" href="{{asset "built/screen.css"}}">
+
+    {{!-- Custom background color --}}
+    <style>
+        :root {
+            --background-color: {{@custom.site_background_color}}
+        }
+    </style>
+
+    <script>
+        /* The script for calculating the color contrast has been taken from
+        https://gomakethings.com/dynamically-changing-the-text-color-based-on-background-color-contrast-with-vanilla-js/ */
+        var accentColor = getComputedStyle(document.documentElement).getPropertyValue('--background-color');
+        accentColor = accentColor.trim().slice(1);
+
+        if (accentColor.length === 3) {
+            accentColor = accentColor[0] + accentColor[0] + accentColor[1] + accentColor[1] + accentColor[2] + accentColor[2];
+        }
+
+        var r = parseInt(accentColor.substr(0, 2), 16);
+        var g = parseInt(accentColor.substr(2, 2), 16);
+        var b = parseInt(accentColor.substr(4, 2), 16);
+        var yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+        var textColor = (yiq >= 128) ? 'dark' : 'light';
+
+        document.documentElement.className = `has-${textColor}-text`;
+    </script>
+
+    {{!-- This tag outputs all your advanced SEO meta, structured data, and other important settings, it should always be the last tag before the closing head tag --}}
+    {{ghost_head}}
+
+</head>
+<body class="{{body_class}} has-{{#match @custom.title_font "Elegant serif"}}serif{{else match @custom.title_font "Consistent mono"}}mono{{else}}sans{{/match}}-title has-{{#match @custom.body_font "Elegant serif"}}serif{{else}}sans{{/match}}-body">
+
+<div class="gh-viewport">
+
+    {{> "components/navigation" navigationLayout=@custom.navigation_layout}}
+
+    {{> "announcement-bar"}}
+
+    {{{body}}}
+
+    {{> "components/footer"}}
+
+</div>
+
+{{#is "post, page"}}
+    {{> "lightbox"}}
+{{/is}}
+
+{{!-- Scripts - handle responsive videos, infinite scroll, and navigation dropdowns --}}
+<script src="{{asset "built/source.js"}}"></script>
+
+{{!-- Ghost outputs required functional scripts with this tag, it should always be the last thing before the closing body tag --}}
+{{ghost_foot}}
+
+</body>
+</html>

--- a/ghost/partials/announcement-bar.hbs
+++ b/ghost/partials/announcement-bar.hbs
@@ -1,0 +1,129 @@
+<style>
+    .gh-announcement-bar,.gh-announcement-bar * {
+        box-sizing: border-box !important;
+    }
+
+    .gh-announcement-bar {
+        position:relative;
+        z-index:90;
+        display:flex;
+        align-items:center;
+        justify-content:center;
+        padding:12px 48px;
+        min-height:48px;
+        font-size:15px;
+        line-height:23px;
+        text-align:center;
+    }
+
+    .gh-announcement-bar.light {
+        background-color: #eeeeeecc;
+        backdrop-filter: blur(6px);
+        color: #15171a;
+    }
+
+    .gh-announcement-bar.accent {
+        background-color: var(--ghost-accent-color);
+        color: #fff;
+    }
+
+    .gh-announcement-bar.dark {
+        background-color: #15171a;
+        color: #fff;
+    }
+
+    .gh-announcement-bar *:not(path) {
+        all:unset
+    }
+
+    .gh-announcement-bar strong {
+        font-weight:700
+    }
+
+    .gh-announcement-bar :is(i,em) {
+        font-style:italic
+    }
+
+    .gh-announcement-bar a {
+        color:#fff;
+        font-weight:700;
+        text-decoration:underline;
+        cursor:pointer;
+    }
+
+    .gh-announcement-bar.light a {
+        color: var(--ghost-accent-color)!important;
+    }
+
+    .gh-announcement-bar button {
+        position: absolute;
+        top: 50%;
+        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-top: -16px;
+        width: 32px;
+        height: 32px;
+        padding: 0;
+        background-color: transparent;
+        border: 0;
+        color: #fff;
+        cursor: pointer;
+    }
+
+    .gh-announcement-bar.light button{
+        color: #888;
+    }
+
+    .gh-announcement-bar svg{
+        width: 10px;
+        height: 10px;
+        fill: currentColor;
+    }
+</style>
+
+<div id="announcement-bar-root" style="position: sticky; top: 0px; z-index: 9999;">
+    <div class="gh-announcement-bar light">
+        <div class="gh-announcement-bar-content">
+            <p dir="ltr">
+                <span>Try our </span>
+                <a href="https://portal.biodiversitycellatlas.org" rel="noreferrer">BCA Data Portal</a>
+                <span> demo and share your feedback!</span>
+            </p>
+        </div>
+        <button aria-label="close" onclick="hideAnnouncementBar(true)">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                 height="16" width="16">
+                <path stroke-linecap="round" fill="currentColor"
+                 stroke-width="0.4" stroke="#000000" stroke-linejoin="round"
+                 d="M.44,21.44a1.49,1.49,0,0,0,0,2.12,1.5,1.5,0,0,0,2.12,0l9.26-9.26a.25.25,0,0,1,.36,0l9.26,9.26a1.5,1.5,0,0,0,2.12,0,1.49,1.49,0,0,0,0-2.12L14.3,12.18a.25.25,0,0,1,0-.36l9.26-9.26A1.5,1.5,0,0,0,21.44.44L12.18,9.7a.25.25,0,0,1-.36,0L2.56.44A1.5,1.5,0,0,0,.44,2.56L9.7,11.82a.25.25,0,0,1,0,.36Z"></path>
+            </svg>
+        </button>
+    </div>
+</div>
+
+<script>
+    /**
+     * Hides the announcement bar.
+     * @param {boolean} persist - whether to save the dismissal in localStorage
+     */
+    function hideAnnouncementBar(persist = false) {
+        const bar = document.getElementById('announcement-bar-root');
+        if (bar) bar.style.display = 'none';
+        if (persist) localStorage.setItem('announcement-closed', Date.now());
+    }
+
+    /**
+     * Hide the announcement bar if closed within the last 7 days.
+     */
+    (function checkAnnouncementBar() {
+        const closed = new Date(parseInt(localStorage.getItem('announcement-closed')));
+        const cutoff = new Date();
+        cutoff.setDate(cutoff.getDate() - 7);
+
+        if (closed > cutoff) {
+            hideAnnouncementBar();
+        }
+    })();
+</script>

--- a/ghost/partials/components/footer.hbs
+++ b/ghost/partials/components/footer.hbs
@@ -1,0 +1,46 @@
+<style>
+    .gh-footer {
+        margin-top: 6vw;
+    }
+</style>
+
+<footer class="gh-footer{{#match @custom.header_and_footer_color "Accent color"}} has-accent-color{{/match}} gh-outer">
+    <div class="gh-footer-inner gh-inner">
+
+        <div class="gh-footer-bar" style="border-block: none; margin-bottom: 0px;">
+            <span class="gh-footer-logo is-title">
+                <a class="gh-navigation-logo is-title"
+                   href="{{@site.url}}" style="display: contents;">
+                    {{#if @site.logo}}
+                        <img src="{{@site.logo}}" alt="{{@site.title}}">
+                    {{else}}
+                        {{@site.title}}
+                    {{/if}}
+                </a>
+            </span>
+            <nav class="gh-footer-menu">
+                {{navigation type="secondary"}}
+            </nav>
+            <div class="gh-footer-copyright">
+                <a href='mailto:bca@biodiversitycellatlas.org' style="text-decoration: none;">
+                    bca@biodiversitycellatlas.org
+                </a>
+            </div>
+        </div>
+
+        {{#if @site.members_enabled}}
+            {{#unless @member}}
+                <section class="gh-footer-signup">
+                    <h2 class="gh-footer-signup-header is-title">
+                        {{#if @custom.signup_heading}}{{@custom.signup_heading}}{{else}}{{@site.title}}{{/if}}
+                    </h2>
+                    <p class="gh-footer-signup-subhead is-body">
+                        {{#if @custom.signup_subheading}}{{@custom.signup_subheading}}{{else}}{{@site.description}}{{/if}}
+                    </p>
+                    {{> "email-subscription" email_field_id="footer-email"}}
+                </section>
+            {{/unless}}
+        {{/if}}
+
+    </div>
+</footer>

--- a/ghost/partials/components/post-list.hbs
+++ b/ghost/partials/components/post-list.hbs
@@ -1,0 +1,170 @@
+{{!--
+    Parameters:
+    * feed (index, home, archive, recent)
+    * postFeedStyle (list, grid)
+    * showTitle (true, false)
+    * showSidebar (true, false)
+--}}
+
+<style>
+    .tag-btn {
+        background: #f0f0f0;
+        border: none;
+        border-radius: 12px;
+        padding: 4px 12px;
+        margin-right: 6px;
+        font-size: 0.9em;
+        cursor: pointer;
+        color: #333;
+    }
+
+    .tag-btn:hover {
+        background: #ddd;
+    }
+
+    .gh-container-title.tag-buttons {
+        border-bottom: none;
+    }
+</style>
+
+{{#if showTitle}}
+    <section class="gh-header is-classic has-image gh-outer">
+        <img class="gh-header-image" src="https://images.unsplash.com/photo-1514907283155-ea5f4094c70c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDZ8fGNvcmFsfGVufDB8fHx8MTc0NTkzNDEyNHww&ixlib=rb-4.0.3&q=80&w=2000" alt="Biodiversity Cell Atlas">
+        <div class="gh-header-inner gh-inner">
+            <h1 class="gh-header-title is-title">BCA Blog</h1>
+            <form class="gh-form">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" width="20" height="20">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                </svg>
+                <button class="gh-form-input" data-ghost-search="">Search posts, tags and authors</button>
+            </form>
+        </div>
+    </section>
+{{/if}}
+
+<section class="gh-container is-{{#match postFeedStyle "List"}}list{{else}}grid{{/match}}{{#if showSidebar}} has-sidebar{{/if}}{{#unless @custom.show_images_in_feed}} no-image{{/unless}} gh-outer">
+    <div class="gh-container-inner gh-inner">
+
+        <!-- Tag shortcuts -->
+        <div class="gh-container-title tag-buttons" style="margin-top: 1em;">
+            <center>
+                <a class="tag-btn" href="tag/news">News</a>
+                <a class="tag-btn" href="tag/media">Media</a>
+                <a class="tag-btn" href="tag/meetings">Meetings</a>
+                <a class="tag-btn" href="tag/publications">Publications</a>
+                <a class="tag-btn" href="tag/tutorials">Tutorials</a>
+            </center>
+        </div>
+
+        {{#if showTitle}}
+            <h2 class="gh-container-title">
+                {{#unless title}}Latest{{else}}{{title}}{{/unless}}
+            </h2>
+        {{/if}}
+
+        <main class="gh-main">
+            <div class="gh-feed">
+
+                {{!-- Homepage --}}
+                {{#match feed "home"}}
+                    {{#match @custom.header_style "Highlight"}}
+                        {{#if @custom.show_featured_posts}}
+                            {{#match posts.length ">=" 4}}
+                                {{#get "posts" include="authors" limit="16"}}
+                                    {{#foreach posts from="5"}}
+                                        {{> "post-card" lazyLoad=true}}
+                                    {{/foreach}}
+                                {{/get}}
+                            {{/match}}
+                        {{else}}
+                            {{#match posts.length ">=" 10}}
+                                {{#get "posts" include="authors" limit="22"}}
+                                    {{#foreach posts from="11"}}
+                                        {{> "post-card" lazyLoad=true}}
+                                    {{/foreach}}
+                                {{/get}}
+                            {{/match}}
+                        {{/if}}
+                    {{else match @custom.header_style "Magazine"}}
+                        {{#match posts.length ">=" 7}}
+                            {{#get "posts" include="authors" limit="19"}}
+                                {{#foreach posts from="8"}}
+                                    {{> "post-card" lazyLoad=true}}
+                                {{/foreach}}
+                            {{/get}}
+                        {{/match}}
+                    {{else}}
+                        {{#get "posts" include="authors" limit="12"}}
+                            {{#foreach posts}}
+                                {{> "post-card" lazyLoad=true}}
+                            {{/foreach}}
+                        {{/get}}
+                    {{/match}}
+                {{/match}}
+
+                {{!-- All posts --}}
+                {{#match feed "index"}}
+                    {{#match pagination.page 2}}
+                        {{#get "posts" include="authors" limit=@config.posts_per_page as |recent|}}
+                            {{#foreach recent}}
+                                {{> "post-card"}}
+                            {{/foreach}}
+                        {{/get}}
+                    {{/match}}
+                    {{#foreach posts}}
+                        {{> "post-card" lazyLoad=true}}
+                    {{/foreach}}
+                {{/match}}
+
+                {{!-- Tag and author pages --}}
+                {{#match feed "archive"}}
+                    {{#foreach posts}}
+                        {{> "post-card" lazyLoad=true}}
+                    {{/foreach}}
+                {{/match}}
+
+            </div>
+
+            {{#match pagination.pages ">" 1}}
+                <div class="gh-more is-title">
+                    <a href="{{@site.url}}/page/2">See all {{> "icons/arrow"}}</a>
+                </div>
+            {{/match}}
+        </main>
+
+        {{#if showSidebar}}
+            <aside class="gh-sidebar">
+                <div class="gh-sidebar-inner">
+                    <section class="gh-about">
+                        {{#if @site.icon}}
+                            <img class="gh-about-icon" src="{{@site.icon}}" alt="{{@site.title}}" loading="lazy">
+                        {{/if}}
+                        <h3 class="gh-about-title is-title">{{@site.title}}</h3>
+                        {{#if @site.description}}
+                            <p class="gh-about-description is-body">{{@site.description}}</p>
+                        {{/if}}
+                        {{#if @site.members_enabled}}
+                            {{#unless @member}}
+                                <button class="gh-button" data-portal="signup">Subscribe</button>
+                            {{else}}
+                                {{#if @site.paid_members_enabled}}
+                                    {{#unless @member.paid}}
+                                        <button class="gh-button" data-portal="upgrade">Upgrade</button>
+                                    {{/unless}}
+                                {{/if}}
+                            {{/unless}}
+                        {{/if}}
+                    </section>
+                    {{#if @site.recommendations_enabled}}
+                        <section class="gh-recommendations">
+                            <h4 class="gh-sidebar-title">Recommendations</h4>
+                            {{recommendations}}
+                            <button data-portal="recommendations">See all {{> "icons/arrow"}}</button>
+                        </section>
+                    {{/if}}
+                </div>
+            </aside>
+        {{/if}}
+
+    </div>
+</section>


### PR DESCRIPTION
@toniher: as discussed, I mounted the Ghost theme files in [compose.yml](https://github.com/biodiversitycellatlas/bca-website/blob/5091aa66407223677c3d3da252af54df4ed400c5/compose.yml#L22-L25) to allow editing the theme via HTML[^1] instead of using code injection.

Now, it is easy to add the analytics script in the file [ghost/default.hbs](https://github.com/biodiversitycellatlas/bca-website/blob/ghost-theme/ghost/default.hbs).

Changes reflected in staging server: http://localhost/website/

[^1]: Ghost uses [Handlebars](https://handlebarsjs.com) to create HTML templates.