### PR TITLE
Add django-prometheus for metrics

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -79,9 +79,11 @@ INSTALLED_APPS = [
     "colorfield",
     "drf_spectacular",
     "django_extensions",
+    "django_prometheus",
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -89,6 +91,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 if DEBUG:
@@ -123,7 +126,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
+        "ENGINE": "django_prometheus.db.backends.postgresql",
         "NAME": get_env("POSTGRES_DB"),
         "USER": get_env("POSTGRES_USER"),
         "PASSWORD": get_env("POSTGRES_PASSWORD"),

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
         lambda request: redirect(reverse("rest:index"), permanent=False),
         name="api",
     ),
+    path("", include('django_prometheus.urls')),
 ]
 
 if settings.DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ djangorestframework==3.16.1
 django-filter==25.1
 drf-spectacular==0.28.0
 
+# Monitoring
+django-prometheus==2.4.1
+
 # dev
 django-debug-toolbar==5.2.0
 django-extensions==4.1


### PR DESCRIPTION
Hi @nuno-agostinho. Just added here [django-prometheus](https://pypi.org/project/django-prometheus/). Once it is merged I will update the production environment and then the metrics will be available under: [portal.biodiversitycellatlas.org/metrics](portal.biodiversitycellatlas.org/metrics)

Afterwards, I can create a graphana dashboard to see all those metrics.

