### PR TITLE
Improve djlint code linting

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,3 +1,4 @@
 {
-    "preserve_blank_lines": true
+    "preserve_blank_lines": true,
+    "line_break_after_multiline_tag": true
 }

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -97,7 +97,7 @@ jobs:
                   filter_mode: diff_context
 
             - name: Report all djlint issues
-              run: djlint . --preserve-blank-lines
+              run: djlint .
 
     autoprefix:
         name: Autoprefixer (CSS)

--- a/app/templates/403.html
+++ b/app/templates/403.html
@@ -5,7 +5,9 @@
 
 {% endcomment %}
 
-{% block title %}403: permission denied{% endblock %}
+{% block title %}
+    403: permission denied
+{% endblock %}
 
 {% block description %}
     It seems you do not have permission to access this page...
@@ -13,12 +15,18 @@
     <a href="{% url 'about' %}#contact">contact us</a>!
 {% endblock %}
 
-{% block img %}https://images.unsplash.com/photo-1500189001820-d65835a662d4{% endblock %}
+{% block img %}
+    https://images.unsplash.com/photo-1500189001820-d65835a662d4
+{% endblock %}
 
 {% block img_alt %}
     A brown deer walks across a snow-covered landscape, casting a shadow on the white ground.
 {% endblock %}
 
-{% block author %}Jeremy Perkins{% endblock %}
+{% block author %}
+    Jeremy Perkins
+{% endblock %}
 
-{% block author_url %}https://unsplash.com/@jeremyperkins{% endblock %}
+{% block author_url %}
+    https://unsplash.com/@jeremyperkins
+{% endblock %}

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -6,19 +6,27 @@
 
 {% endcomment %}
 
-{% block title %}404: page not found{% endblock %}
+{% block title %}
+    404: page not found
+{% endblock %}
 
 {% block description %}
     We cannot find the page you requested... If you think something is wrong,
     please <a href="{% url 'about' %}#contact">contact us</a>!
 {% endblock %}
 
-{% block img %}https://images.unsplash.com/photo-1500189001820-d65835a662d4{% endblock %}
+{% block img %}
+    https://images.unsplash.com/photo-1500189001820-d65835a662d4
+{% endblock %}
 
 {% block img_alt %}
     A brown deer walks across a snow-covered landscape, casting a shadow on the white ground.
 {% endblock %}
 
-{% block author %}Jeremy Perkins{% endblock %}
+{% block author %}
+    Jeremy Perkins
+{% endblock %}
 
-{% block author_url %}https://unsplash.com/@jeremyperkins{% endblock %}
+{% block author_url %}
+    https://unsplash.com/@jeremyperkins
+{% endblock %}

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -6,7 +6,9 @@
 
 {% endcomment %}
 
-{% block title %}500: server error{% endblock %}
+{% block title %}
+    500: server error
+{% endblock %}
 
 {% block description %}
     Try to refresh this page or
@@ -14,10 +16,18 @@
     if the issue persists.
 {% endblock %}
 
-{% block img %}https://images.unsplash.com/photo-1741994561367-3d488663f6da{% endblock %}
+{% block img %}
+    https://images.unsplash.com/photo-1741994561367-3d488663f6da
+{% endblock %}
 
-{% block img_alt %}A close-up of a toad on a white background.{% endblock %}
+{% block img_alt %}
+    A close-up of a toad on a white background.
+{% endblock %}
 
-{% block author %}John Cardamone{% endblock %}
+{% block author %}
+    John Cardamone
+{% endblock %}
 
-{% block author_url %}https://unsplash.com/@john_cardamone{% endblock %}
+{% block author_url %}
+    https://unsplash.com/@john_cardamone
+{% endblock %}

--- a/app/templates/app/about.html
+++ b/app/templates/app/about.html
@@ -18,7 +18,9 @@ Features:
 
     {% load bca_website_links %}
 
-    <h1 class="h3" id="about">About us</h1>
+    <h1 class="h3" id="about">
+        About us
+    </h1>
 
     <p class="pb-3">
         The <a href="{% bca_url %}" target="_blank">Biodiversity Cell Atlas</a> (BCA)

--- a/app/templates/app/atlas/gene.html
+++ b/app/templates/app/atlas/gene.html
@@ -46,11 +46,15 @@ Input:
             <button type="button"
                     class="btn btn-link btn-sm"
                     data-bs-toggle="modal"
-                    data-bs-target="#selection_gene_lists_editor">Select from gene lists...</button>
+                    data-bs-target="#selection_gene_lists_editor">
+                Select from gene lists...
+            </button>
             <button type="button"
                     class="btn btn-link btn-sm"
                     data-bs-toggle="modal"
-                    data-bs-target="#selection_alignment">Select from sequence search...</button>
+                    data-bs-target="#selection_alignment">
+                Select from sequence search...
+            </button>
         </div>
     </div>
 
@@ -74,12 +78,16 @@ Input:
                 <table class="table table-sm table-striped gene-info">
                     <tbody>
                         <tr>
-                            <td class="key">Pfam domains</td>
+                            <td class="key">
+                                Pfam domains
+                            </td>
                             <td>
                                 {% if gene.domains.all %}
                                     {% for domain in gene.domains.all %}
                                         <a href="{{ domain.query_url }}" target="_blank">{{ domain }}</a>
-                                        {% if not forloop.last %},{% endif %}
+                                        {% if not forloop.last %}
+                                            ,
+                                        {% endif %}
                                     {% endfor %}
                                 {% else %}
                                     —
@@ -88,18 +96,30 @@ Input:
                         </tr>
 
                         <tr>
-                            <td class="key">Gene lists</td>
-                            <td>{{ gene.genelists.all|join:", "|default:'—' }}</td>
+                            <td class="key">
+                                Gene lists
+                            </td>
+                            <td>
+                                {{ gene.genelists.all|join:", "|default:'—' }}
+                            </td>
                         </tr>
 
                         <tr>
-                            <td class="key">Gene modules</td>
-                            <td>{{ gene.modules.all|join:", "|default:'—' }}</td>
+                            <td class="key">
+                                Gene modules
+                            </td>
+                            <td>
+                                {{ gene.modules.all|join:", "|default:'—' }}
+                            </td>
                         </tr>
 
                         <tr>
-                            <td class="key">Orthogroup</td>
-                            <td>{{ gene.orthogroup_html_link|default:"—" }}</td>
+                            <td class="key">
+                                Orthogroup
+                            </td>
+                            <td>
+                                {{ gene.orthogroup_html_link|default:"—" }}
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/app/templates/app/atlas/info.html
+++ b/app/templates/app/atlas/info.html
@@ -39,9 +39,13 @@ Input:
         <div class="col-md-4">
 
             <!-- Show image and credits -->
-            <p>{% include "../components/dataset_image.html" %}</p>
+            <p>
+                {% include "../components/dataset_image.html" %}
+            </p>
 
-            <h2 class="h5 mt-4">Dataset information</h2>
+            <h2 class="h5 mt-4">
+                Dataset information
+            </h2>
 
             <table class="table table-sm table-striped mx-auto">
                 <tbody>
@@ -49,18 +53,24 @@ Input:
                         <td>
                             <span class="key">Release date</span>
                         </td>
-                        <td class="text-end">{{ dataset.date_created|date:"j F Y" }}</td>
+                        <td class="text-end">
+                            {{ dataset.date_created|date:"j F Y" }}
+                        </td>
                     </tr>
                     <tr>
                         <td>
                             <span class="key">Last update</span>
                         </td>
-                        <td class="text-end">{{ dataset.date_updated|date:"j F Y" }}</td>
+                        <td class="text-end">
+                            {{ dataset.date_updated|date:"j F Y" }}
+                        </td>
                     </tr>
                 </tbody>
             </table>
 
-            <h2 class="h5 mt-4">Metadata</h2>
+            <h2 class="h5 mt-4">
+                Metadata
+            </h2>
 
             <table class="table table-sm table-striped mx-auto">
                 <tbody>
@@ -94,16 +104,24 @@ Input:
             {% load headings %}
             {% h1 dataset.get_html id="info" %}
 
-            <p>{{ species.description|default:'No description available.'|safe }}</p>
+            <p>
+                {{ species.description|default:'No description available.'|safe }}
+            </p>
 
             <div class="row text-center mt-5">
                 <div class="col-6 col-lg-3">
-                    <p id="n_cells" class="h3 mb-0">0</p>
-                    <p>cells</p>
+                    <p id="n_cells" class="h3 mb-0">
+                        0
+                    </p>
+                    <p>
+                        cells
+                    </p>
                 </div>
 
                 <div class="col-6 col-lg-3">
-                    <p id="n_metacells" class="h3 mb-0">0</p>
+                    <p id="n_metacells" class="h3 mb-0">
+                        0
+                    </p>
                     <a data-bs-toggle="tooltip"
                        data-bs-placement="bottom"
                        data-bs-title="Groups of cells with highly similar gene expression">
@@ -112,7 +130,9 @@ Input:
                 </div>
 
                 <div class="col-6 col-lg-3">
-                    <p id="n_umis" class="h3 mb-0">0</p>
+                    <p id="n_umis" class="h3 mb-0">
+                        0
+                    </p>
                     <a data-bs-toggle="tooltip"
                        data-bs-placement="bottom"
                        data-bs-title="Total number of Unique Molecular Identifiers (UMIs)">
@@ -121,15 +141,23 @@ Input:
                 </div>
 
                 <div class="col-6 col-lg-3">
-                    <p id="n_genes" class="h3 mb-0">0</p>
-                    <p>genes</p>
+                    <p id="n_genes" class="h3 mb-0">
+                        0
+                    </p>
+                    <p>
+                        genes
+                    </p>
                 </div>
             </div>
 
             <div class="row mt-3">
-                <div class="col-md-6">{% include '../components/plot_container.html' with id='metacell-cells' height='270px' %}</div>
+                <div class="col-md-6">
+                    {% include '../components/plot_container.html' with id='metacell-cells' height='270px' %}
+                </div>
 
-                <div class="col-md-6">{% include '../components/plot_container.html' with id='metacell-umis' height='270px' %}</div>
+                <div class="col-md-6">
+                    {% include '../components/plot_container.html' with id='metacell-umis' height='270px' %}
+                </div>
             </div>
 
             {% load headings %}

--- a/app/templates/app/atlas/markers.html
+++ b/app/templates/app/atlas/markers.html
@@ -34,15 +34,21 @@ Input:
         <div class="col-md-3">
             <form>
                 <fieldset>
-                    <legend class="h5">Cell selection</legend>
+                    <legend class="h5">
+                        Cell selection
+                    </legend>
                     <div class="mb-3">
-                        <label class="col-form-label" for="metacells">Metacells</label>
+                        <label class="col-form-label" for="metacells">
+                            Metacells
+                        </label>
                         {% include '../components/select/metacell.html' with metacell_dict=metacell_dict selected=query.metacells %}
                     </div>
                 </fieldset>
 
                 <fieldset>
-                    <legend class="h5">Fold-change</legend>
+                    <legend class="h5">
+                        Fold-change
+                    </legend>
                     <div class="mb-3">
                         <label class="col-form-label" for="fc_min_type">
                             Min. fold-change <i class="fa fa-circle-question"
@@ -56,9 +62,13 @@ Input:
                                 aria-label="Select example"
                                 value="median">
                             <option value="mean"
-                                    {% if query.fc_max_bg_type == 'mean' %}selected{% endif %}>Mean</option>
+                                    {% if query.fc_max_bg_type == 'mean' %}selected{% endif %}>
+                                Mean
+                            </option>
                             <option value="median"
-                                    {% if query.fc_max_bg_type == 'median' %}selected{% endif %}>Median</option>
+                                    {% if query.fc_max_bg_type == 'median' %}selected{% endif %}>
+                                Median
+                            </option>
                         </select>
                     </div>
 
@@ -83,11 +93,17 @@ Input:
                                 aria-label="Select example"
                                 onchange="toggleMaxFCslider(this, '#fc_max_bg');">
                             <option value="ignore"
-                                    {% if query.fc_max_bg_type == 'ignore' %}selected{% endif %}>Ignore</option>
+                                    {% if query.fc_max_bg_type == 'ignore' %}selected{% endif %}>
+                                Ignore
+                            </option>
                             <option value="mean"
-                                    {% if query.fc_max_bg_type == 'mean' %}selected{% endif %}>Mean</option>
+                                    {% if query.fc_max_bg_type == 'mean' %}selected{% endif %}>
+                                Mean
+                            </option>
                             <option value="median"
-                                    {% if query.fc_max_bg_type == 'median' %}selected{% endif %}>Median</option>
+                                    {% if query.fc_max_bg_type == 'median' %}selected{% endif %}>
+                                Median
+                            </option>
                         </select>
                     </div>
 
@@ -98,7 +114,9 @@ Input:
                            value="{{ query.fc_max_bg|default:3 }}"
                            step="0.1"
                            disabled>
-                    <button type="submit" class="btn btn-primary my-3 w-100">List markers</button>
+                    <button type="submit" class="btn btn-primary my-3 w-100">
+                        List markers
+                    </button>
                 </fieldset>
             </form>
         </div>

--- a/app/templates/app/components/buttons/data_download.html
+++ b/app/templates/app/components/buttons/data_download.html
@@ -22,7 +22,9 @@
 
 <ul id="data_dropdown_{{ id }}" class="dropdown-menu">
     <li class="d-flex justify-content-end align-items-center">
-        <label class="col-form-label-sm me-2 text-secondary">Format</label>
+        <label class="col-form-label-sm me-2 text-secondary">
+            Format
+        </label>
 
         <form>
             <div class="btn-group" role="group">
@@ -35,7 +37,9 @@
                                value="{{ format }}"
                                autocomplete="off">
                         <label class="btn btn-outline-secondary btn-xs"
-                               for="data_format_{{ id }}_{{ format }}">{{ format | upper }}</label>
+                               for="data_format_{{ id }}_{{ format }}">
+                            {{ format | upper }}
+                        </label>
                     {% endfor %}
                 {% endwith %}
             </div>
@@ -46,7 +50,9 @@
 
     <template id="data_template_{{ id }}">
         <li name="data_download_option">
-            <label class="key-label">Label</label>
+            <label class="key-label">
+                Label
+            </label>
             <div class="btn-toolbar ms-2 float-end" role="toolbar">
                 <div class="btn-group me-2" role="group">
                     <a name="data_view_{{ id }}"

--- a/app/templates/app/components/cards/news_card.html
+++ b/app/templates/app/components/cards/news_card.html
@@ -23,7 +23,9 @@ Input:
     <div class="news card card-cover h-100 overflow-hidden text-bg-dark rounded-4 shadow-sm text-shadow"
          style="background-image: url('{{ img_url }}')">
         <div class="d-flex flex-column h-100 p-5 text-white">
-            <h2 class="h4">{{ title }}</h2>
+            <h2 class="h4">
+                {{ title }}
+            </h2>
             <ul class="d-flex list-unstyled mt-auto">
                 <li class="d-flex align-items-center">
                     <span><small>

--- a/app/templates/app/components/cards/qc_card.html
+++ b/app/templates/app/components/cards/qc_card.html
@@ -26,8 +26,12 @@ Input:
              style="background-image: url('{{ img_url }}?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D');
                     background-position:center;
                     background-size:cover">
-            <h3 class="h6 card-title text-shadow">{{ title }}</h3>
-            <p class="card-text text-shadow mb-4">{{ description }}</p>
+            <h3 class="h6 card-title text-shadow">
+                {{ title }}
+            </h3>
+            <p class="card-text text-shadow mb-4">
+                {{ description }}
+            </p>
 
             <figcaption class="w-100 position-absolute text-end text-dark bottom-0 start-0 py-2 px-4 bg-white bg-opacity-75 opacity-0 small">
                 Photo by

--- a/app/templates/app/components/entry_header_count.html
+++ b/app/templates/app/components/entry_header_count.html
@@ -5,9 +5,13 @@ Entry header with counter
 {% endcomment %}
 
 <div class="d-flex align-items-end">
-    <h1 class="h3 text-break me-2">{{ title }}</h1>
+    <h1 class="h3 text-break me-2">
+        {{ title }}
+    </h1>
 
-    {% if object %}<span class="mb-2 me-2">{{ object.get_html_link }}</span>{% endif %}
+    {% if object %}
+        <span class="mb-2 me-2">{{ object.get_html_link }}</span>
+    {% endif %}
 
     <span class="mb-2 text-muted">
         {{ paginator.count }}

--- a/app/templates/app/components/heading.html
+++ b/app/templates/app/components/heading.html
@@ -1,5 +1,7 @@
 <{{ tag|default:"h1" }}
-{% if id %}id={{ id }}{% endif %}
+{% if id %}
+    id={{ id }}
+{% endif %}
 class="{{ h_class }} d-flex flex-wrap pt-2 mb-3">
 
 <span>{{ title|safe }}</span>

--- a/app/templates/app/components/links/breadcrumbs.html
+++ b/app/templates/app/components/links/breadcrumbs.html
@@ -8,7 +8,9 @@
     <ol class="breadcrumb mb-0">
         {% for label, url in crumbs %}
             {% if forloop.last %}
-                <li class="breadcrumb-item active" aria-current="page">{{ label }}</li>
+                <li class="breadcrumb-item active" aria-current="page">
+                    {{ label }}
+                </li>
             {% else %}
                 <li class="breadcrumb-item">
                     <a href="{{ url }}">{{ label }}</a>

--- a/app/templates/app/components/links/card.html
+++ b/app/templates/app/components/links/card.html
@@ -44,15 +44,24 @@
     {% endif %}
 
     <div class="card-body">
-        {% if title %}<h3 class="h5 card-title">{{ title }}</h3>{% endif %}
+        {% if title %}
+            <h3 class="h5 card-title">
+                {{ title }}
+            </h3>
+        {% endif %}
 
-        {% if description %}<p class="card-text">{{ description }}</p>{% endif %}
+        {% if description %}
+            <p class="card-text">
+                {{ description }}
+            </p>
+        {% endif %}
 
         {% if links %}
             {% load cards %}
             {% links_list links %}
         {% endif %}
 
-        {% block links %}{% endblock %}
+        {% block links %}
+        {% endblock %}
     </div>
 </div>

--- a/app/templates/app/components/links/download_links.html
+++ b/app/templates/app/components/links/download_links.html
@@ -8,5 +8,7 @@ Reusable block for rendering species or dataset download links in multiple forma
     <a {% if type == 'button' %}class="btn btn-primary btn-xs"{% endif %}
        href="{% url view %}?{% if slug %}dataset={{ slug }}{% endif %}&limit=0&format={{ ext }}"
        download="{% if slug %}{{ slug }} {% endif %}{{ suffix }}.{{ ext }}">{{ ext|upper }}</a>
-    {% if type|default:'link' == "link" and not forloop.last %}•{% endif %}
+    {% if type|default:'link' == "link" and not forloop.last %}
+        •
+    {% endif %}
 {% endfor %}

--- a/app/templates/app/components/lists/news_list.html
+++ b/app/templates/app/components/lists/news_list.html
@@ -6,13 +6,19 @@
     <small>
         {% if category == 'publications' %}
 
-            {% if date %}<span class="text-nowrap"><span class="fa fa-calendar-days fa-fw"></span> {{ date }}</span>{% endif %}
+            {% if date %}
+                <span class="text-nowrap"><span class="fa fa-calendar-days fa-fw"></span> {{ date }}</span>
+            {% endif %}
 
-            {% if journal %}<span class="text-nowrap"><span class="fa fa-file-lines fa-fw"></span> {{ journal }}</span>{% endif %}
+            {% if journal %}
+                <span class="text-nowrap"><span class="fa fa-file-lines fa-fw"></span> {{ journal }}</span>
+            {% endif %}
 
         {% elif category == 'meetings' %}
 
-            {% if date %}<span class="text-nowrap"><span class="fa fa-calendar fa-fw"></span> {{ date }}</span>{% endif %}
+            {% if date %}
+                <span class="text-nowrap"><span class="fa fa-calendar fa-fw"></span> {{ date }}</span>
+            {% endif %}
 
             {% if location %}
                 {% with location|split:", " as parts %}
@@ -28,7 +34,9 @@
                 <span class="text-nowrap"><span class="fa fa-list-ol fa-fw"></span> Text</span>
             {% endif %}
 
-            {% if date %}<span class="text-nowrap"><span class="fa fa-calendar-days fa-fw"></span> {{ date }}</span>{% endif %}
+            {% if date %}
+                <span class="text-nowrap"><span class="fa fa-calendar-days fa-fw"></span> {{ date }}</span>
+            {% endif %}
 
         {% endif %}
     </small>

--- a/app/templates/app/components/mockup/table.html
+++ b/app/templates/app/components/mockup/table.html
@@ -22,10 +22,18 @@ Mockup table
 <table class="table">
     <thead>
         <tr>
-            <th scope="col">#</th>
-            <th scope="col">Gene ID</th>
-            <th scope="col">Description</th>
-            <th scope="col">Domains</th>
+            <th scope="col">
+                #
+            </th>
+            <th scope="col">
+                Gene ID
+            </th>
+            <th scope="col">
+                Description
+            </th>
+            <th scope="col">
+                Domains
+            </th>
         </tr>
     </thead>
     {# djlint:off H021 #}

--- a/app/templates/app/components/modals/alignment.html
+++ b/app/templates/app/components/modals/alignment.html
@@ -17,19 +17,24 @@ Input:
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h1 class="modal-title fs-5">Sequence alignment</h1>
+                <h1 class="modal-title fs-5">
+                    Sequence alignment
+                </h1>
                 <span class="ms-2 me-5 small">{{ species.get_html_link }}</span>
 
                 <div class="ms-auto d-flex align-items-center">
                     <button type="button"
                             class="btn-close"
                             data-bs-dismiss="modal"
-                            aria-label="Close"></button>
+                            aria-label="Close">
+                    </button>
                 </div>
             </div>
             <div class="modal-body">
                 <div class="row mb-2 small">
-                    <label class="col-lg-2 col-form-label small">Aligner</label>
+                    <label class="col-lg-2 col-form-label small">
+                        Aligner
+                    </label>
                     <div class="col-lg-10">
                         <a class="form-control-plaintext"
                            target="_blank"
@@ -41,7 +46,9 @@ Input:
                 </div>
 
                 <div class="row mb-2 small">
-                    <label class="col-lg-2 col-form-label small">Proteome</label>
+                    <label class="col-lg-2 col-form-label small">
+                        Proteome
+                    </label>
                     <div class="col-lg-10">
                         <span class="form-control-plaintext">
                             <img class="rounded"
@@ -56,7 +63,9 @@ Input:
                 </div>
 
                 <div class="row mb-2 small">
-                    <label class="col-lg-2 col-form-label small">Type</label>
+                    <label class="col-lg-2 col-form-label small">
+                        Type
+                    </label>
                     <div class="col-lg-10">
                         <div class="btn-group btn-group-sm mb-3 w-100" role="group">
                             <input type="radio"
@@ -65,7 +74,9 @@ Input:
                                    id="{{ id }}_type_nucleotides"
                                    autocomplete="off"
                                    value="nucleotides">
-                            <label class="btn btn-outline-primary" for="{{ id }}_type_nucleotides">Nucleotides</label>
+                            <label class="btn btn-outline-primary" for="{{ id }}_type_nucleotides">
+                                Nucleotides
+                            </label>
 
                             <input type="radio"
                                    class="btn-check"
@@ -74,13 +85,17 @@ Input:
                                    autocomplete="off"
                                    value="aminoacids"
                                    checked>
-                            <label class="btn btn-outline-primary" for="{{ id }}_type_aminoacids">Amino acids</label>
+                            <label class="btn btn-outline-primary" for="{{ id }}_type_aminoacids">
+                                Amino acids
+                            </label>
                         </div>
                     </div>
                 </div>
 
                 <div class="row mb-2 small">
-                    <label for="{{ id }}_query" class="col-lg-2 col-form-label small">Sequences</label>
+                    <label for="{{ id }}_query" class="col-lg-2 col-form-label small">
+                        Sequences
+                    </label>
                     <div class="col-lg-10">
                         <div class="sequence-input border border-secondary-subtle rounded">
                             <textarea type="textarea"
@@ -110,7 +125,8 @@ Input:
                 </div>
             </div>
 
-            <div id="{{ id }}_alertContainer"></div>
+            <div id="{{ id }}_alertContainer">
+            </div>
             <template id="{{ id }}_errorTemplate">
                 <div role="alert"
                      class="alert alert-danger alert-dismissible fade show m-2">
@@ -120,7 +136,8 @@ Input:
                     <button type="button"
                             class="btn-close"
                             data-bs-dismiss="alert"
-                            aria-label="Close"></button>
+                            aria-label="Close">
+                    </button>
                 </div>
             </template>
 
@@ -133,7 +150,9 @@ Input:
                     <button class="btn btn-outline-primary"
                             href="javascript:void(0);"
                             data-bs-toggle="modal"
-                            data-bs-target="#{{ id }}_{{ type }}_editor">Previous results</button>
+                            data-bs-target="#{{ id }}_{{ type }}_editor">
+                        Previous results
+                    </button>
                     <button type="submit"
                             class="btn btn-primary"
                             id="{{ id }}_align_btn"

--- a/app/templates/app/components/modals/list_editor.html
+++ b/app/templates/app/components/modals/list_editor.html
@@ -32,7 +32,9 @@ Input:
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h1 class="modal-title fs-5" id="{{ id }}_{{ type }}_editor_label">Gene lists</h1>
+                <h1 class="modal-title fs-5" id="{{ id }}_{{ type }}_editor_label">
+                    Gene lists
+                </h1>
                 <span class="ms-2 me-5 small">{{ species.get_html_link }}</span>
 
                 <div class="ms-auto d-flex align-items-center">
@@ -41,7 +43,8 @@ Input:
                     <button type="button"
                             class="btn-close"
                             data-bs-dismiss="modal"
-                            aria-label="Close"></button>
+                            aria-label="Close">
+                    </button>
                 </div>
             </div>
             <div class="modal-body">
@@ -58,10 +61,13 @@ Input:
                                    placeholder="Filter by name of lists...">
                         </div>
 
-                        <div id="{{ id }}_{{ type }}_options" class="list-group"></div>
+                        <div id="{{ id }}_{{ type }}_options" class="list-group">
+                        </div>
 
                         <template id="{{ id }}_{{ type }}_heading">
-                            <div class="list-group-heading py-0 px-2 d-flex justify-content-between">Preset gene lists</div>
+                            <div class="list-group-heading py-0 px-2 d-flex justify-content-between">
+                                Preset gene lists
+                            </div>
                         </template>
 
                         <template id="{{ id }}_{{ type }}_element">
@@ -241,7 +247,9 @@ Input:
                                             <div class="row">
                                                 <div class="col">
                                                     <div class="d-flex justify-content-between align-items-center small">
-                                                        <label class="col-form-label">Select genes to add</label>
+                                                        <label class="col-form-label">
+                                                            Select genes to add
+                                                        </label>
 
                                                         <button type="button"
                                                                 class="btn btn-link btn-sm d-block text-end"
@@ -257,7 +265,9 @@ Input:
                                                     <div class="d-flex mb-0 mt-35px">
                                                         <button id="{{ id }}_{{ type }}_append_btn"
                                                                 type="button"
-                                                                class="btn btn-primary">Add genes</button>
+                                                                class="btn btn-primary">
+                                                            Add genes
+                                                        </button>
                                                     </div>
                                                 </div>
                                             </div>

--- a/app/templates/app/components/plot_container.html
+++ b/app/templates/app/components/plot_container.html
@@ -16,8 +16,11 @@ Input:
 <div id="{{ id }}-plot"
      class="container-xxl"
      style="{% if ratio %}aspect-ratio: {{ ratio }};
-            {% endif %} {% if width %}width: {{ width }};{% endif %} {% if height %}height: {{ height }};{% endif %}">
+            {% endif %} {% if width %}width: {{ width }};
+            {% endif %} {% if height %}height: {{ height }};
+            {% endif %}">
     <div id="{{ id }}-spinner" class="loading-state">
-        <div class="loader"></div>
+        <div class="loader">
+        </div>
     </div>
 </div>

--- a/app/templates/app/components/plots/expression_heatmap.html
+++ b/app/templates/app/components/plots/expression_heatmap.html
@@ -70,13 +70,17 @@ Input:
                         <button type="button"
                                 id="clear_selected_genes"
                                 class="btn btn-link btn-sm d-block text-end"
-                                onclick="$('#{{ id }}_gene_selection')[0].selectize.clear();">Clear selection</button>
+                                onclick="$('#{{ id }}_gene_selection')[0].selectize.clear();">
+                            Clear selection
+                        </button>
 
                         <button type="button"
                                 id="edit_gene_lists"
                                 class="btn btn-link btn-sm d-block text-end"
                                 data-bs-toggle="modal"
-                                data-bs-target="#{{ id }}_gene_lists_editor">Edit gene lists...</button>
+                                data-bs-target="#{{ id }}_gene_lists_editor">
+                            Edit gene lists...
+                        </button>
                     </div>
                 </div>
 
@@ -102,11 +106,15 @@ Input:
                     <div class="mx-4 mb-3 w-250px">
 
                         <div class="d-flex justify-content-between align-items-center small">
-                            <label class="col-form-label">Filter metacells</label>
+                            <label class="col-form-label">
+                                Filter metacells
+                            </label>
                             <button type="button"
                                     id="select_all_metacells"
                                     class="btn btn-link btn-sm d-block text-end"
-                                    onclick="$('#metacells')[0].selectize.clear();">Select all metacells</button>
+                                    onclick="$('#metacells')[0].selectize.clear();">
+                                Select all metacells
+                            </button>
                         </div>
 
                         {% load string_extras %}
@@ -174,7 +182,9 @@ Input:
         </div>
 
         <div class="col-auto">
-            <button id="{{ id }}_submit" type="submit" class="btn btn-primary mt-35px">Apply</button>
+            <button id="{{ id }}_submit" type="submit" class="btn btn-primary mt-35px">
+                Apply
+            </button>
         </div>
     </div>
 </form>
@@ -220,7 +230,9 @@ Input:
 <!-- Use column due to vega-lite's bug with containers for concatenated plots -->
 {% if type|default:'markers' == 'markers' or query.genes %}
     <div class="row">
-        <div class="col-10 col-sm-11">{% include '../plot_container.html' with id=id ratio='16/9' %}</div>
+        <div class="col-10 col-sm-11">
+            {% include '../plot_container.html' with id=id ratio='16/9' %}
+        </div>
     </div>
 
     <script type="module">

--- a/app/templates/app/components/plots/metacell_projection.html
+++ b/app/templates/app/components/plots/metacell_projection.html
@@ -22,27 +22,35 @@ Input:
                    id="{{ id }}-cells"
                    autocomplete="off"
                    checked>
-            <label class="btn btn-outline-primary" for="{{ id }}-cells">Cells</label>
+            <label class="btn btn-outline-primary" for="{{ id }}-cells">
+                Cells
+            </label>
 
             <input type="checkbox"
                    class="btn-check"
                    id="{{ id }}-metacells"
                    autocomplete="off"
                    checked>
-            <label class="btn btn-outline-primary" for="{{ id }}-metacells">Metacells</label>
+            <label class="btn btn-outline-primary" for="{{ id }}-metacells">
+                Metacells
+            </label>
 
             <input type="checkbox"
                    class="btn-check"
                    id="{{ id }}-labels"
                    autocomplete="off"
                    checked>
-            <label class="btn btn-outline-primary" for="{{ id }}-labels">Labels</label>
+            <label class="btn btn-outline-primary" for="{{ id }}-labels">
+                Labels
+            </label>
 
             <input type="checkbox"
                    class="btn-check"
                    id="{{ id }}-links"
                    autocomplete="off">
-            <label class="btn btn-outline-primary" for="{{ id }}-links">Links</label>
+            <label class="btn btn-outline-primary" for="{{ id }}-links">
+                Links
+            </label>
         </div>
     </div>
 
@@ -58,8 +66,12 @@ Input:
                data-bs-title="Click and drag in the plot to select metacells"></i>
         </div>
         <div class="btn-group d-flex" role="group">
-            <button type="button" class="btn btn-outline-primary" id="list_markers">List markers</button>
-            <button type="button" class="btn btn-outline-primary" id="filter_heatmap">Filter heatmap</button>
+            <button type="button" class="btn btn-outline-primary" id="list_markers">
+                List markers
+            </button>
+            <button type="button" class="btn btn-outline-primary" id="filter_heatmap">
+                Filter heatmap
+            </button>
         </div>
     </div>
 </div>

--- a/app/templates/app/components/plots/ortholog_plots.html
+++ b/app/templates/app/components/plots/ortholog_plots.html
@@ -36,7 +36,8 @@ Input:
             <span id="ortholog-dataset">Dataset</span>
         </a>
     </h3>
-    <div id="single-ortholog-plot" class="container-xxl"></div>
+    <div id="single-ortholog-plot" class="container-xxl">
+    </div>
 </template>
 
 {% load static %}

--- a/app/templates/app/components/plots/samap_plot.html
+++ b/app/templates/app/components/plots/samap_plot.html
@@ -62,7 +62,9 @@ Input:
                                step="1">
 
                         <div class="d-flex justify-content-end">
-                            <button id="{{ id }}_submit" type="submit" class="btn btn-primary mt-3">Apply</button>
+                            <button id="{{ id }}_submit" type="submit" class="btn btn-primary mt-3">
+                                Apply
+                            </button>
                         </div>
                     </form>
                 </div>
@@ -85,7 +87,9 @@ Input:
 <!-- Use column due to vega-lite's bug with containers for concatenated plots -->
 {% if dataset2 %}
     <div class="row">
-        <div class="col-10 col-sm-11">{% include '../plot_container.html' with id=id ratio='16/9' %}</div>
+        <div class="col-10 col-sm-11">
+            {% include '../plot_container.html' with id=id ratio='16/9' %}
+        </div>
     </div>
 
     <script type="module">

--- a/app/templates/app/components/select/atlas.html
+++ b/app/templates/app/components/select/atlas.html
@@ -14,7 +14,9 @@ Input:
 
 {% endcomment %}
 
-<div class="container-xxl">{% include './dataset.html' with small='true' %}</div>
+<div class="container-xxl">
+    {% include './dataset.html' with small='true' %}
+</div>
 
 <!-- Subnavbar to navigate the Cell Atlas -->
 <div class="subnavbar sticky-top py-1">
@@ -36,12 +38,15 @@ Input:
              id="offcanvas"
              aria-labelledby="bdSidebarOffcanvasLabel">
             <div class="offcanvas-header border-bottom">
-                <h5 class="offcanvas-title" id="bdSidebarOffcanvasLabel">Cell Atlas</h5>
+                <h5 class="offcanvas-title" id="bdSidebarOffcanvasLabel">
+                    Cell Atlas
+                </h5>
                 <button type="button"
                         class="btn-close"
                         data-bs-dismiss="offcanvas"
                         aria-label="Close"
-                        data-bs-target="#offcanvas"></button>
+                        data-bs-target="#offcanvas">
+                </button>
             </div>
 
             <div class="offcanvas-body">
@@ -68,7 +73,8 @@ Input:
 </div>
 
 <!-- Add some whitespace between subnavbar and content -->
-<div class="mb-2"></div>
+<div class="mb-2">
+</div>
 
 <!-- Set species in cookie -->
 <!--{% if dataset %}

--- a/app/templates/app/components/select/dataset.html
+++ b/app/templates/app/components/select/dataset.html
@@ -41,7 +41,8 @@ Input:
 <select id="dataset-select-{{ id }}"
         class="mb-2 {{ class }} {% if small == 'true' %}small{% endif %}"
         placeholder="{{ placeholder|default:'Search datasets by species, taxonomic rank, division, ...' }}">
-    <option value=""></option>
+    <option value="">
+    </option>
     {% for phylum, dataset_list in dataset_dict.items %}
         <optgroup label="{{ phylum }}">
             {% for elem in dataset_list %}

--- a/app/templates/app/components/select/gene.html
+++ b/app/templates/app/components/select/gene.html
@@ -36,7 +36,8 @@ Input:
         placeholder="{{ placeholder|default:'Search gene...' }}"
         {% if multiple == 'true' %}multiple{% endif %}
         {% if disabled == 'true' %}disabled{% endif %}>
-    <option value=""></option>
+    <option value="">
+    </option>
 </select>
 
 <!-- Species selection: selectize.js JavaScript options -->

--- a/app/templates/app/components/select/metacell.html
+++ b/app/templates/app/components/select/metacell.html
@@ -23,7 +23,8 @@ Input:
         id="metacells"
         multiple
         placeholder="{{ placeholder|default:'Select metacells...' }}">
-    <option value=""></option>
+    <option value="">
+    </option>
     {% for key, value in metacell_dict.items %}
         <optgroup label="{{ key }}">
             {% if key == 'Cell types' %}
@@ -31,14 +32,18 @@ Input:
                     <option value="{{ type }}"
                             data-type="cell_types"
                             data-metacells="{{ mc|join:',' }}"
-                            data-color="{{ type.color }}">{{ type }}</option>
+                            data-color="{{ type.color }}">
+                        {{ type }}
+                    </option>
                 {% endfor %}
             {% elif key == 'Metacells' %}
                 {% for mc in value %}
                     <option value="{{ mc.name }}"
                             data-type="metacells"
                             data-color="{{ mc.type.color }}"
-                            data-celltype="{{ mc.type }}">{{ mc.name }}</option>
+                            data-celltype="{{ mc.type }}">
+                        {{ mc.name }}
+                    </option>
                 {% endfor %}
             {% endif %}
         </optgroup>

--- a/app/templates/app/components/select/species.html
+++ b/app/templates/app/components/select/species.html
@@ -31,7 +31,8 @@ Input:
                visibility: hidden;
                max-width: 200px"
         placeholder="{{ placeholder|default:'Search species by nomenclature, taxonomic rank, division, ...' }}">
-    <option value=""></option>
+    <option value="">
+    </option>
     {% for phylum, species_list in species_dict.items %}
         <optgroup label="{{ phylum }}">
             {% for elem in species_list %}

--- a/app/templates/app/components/warning_alert.html
+++ b/app/templates/app/components/warning_alert.html
@@ -13,6 +13,7 @@ Input:
         <button type="button"
                 class="btn-close"
                 data-bs-dismiss="alert"
-                aria-label="Close"></button>
+                aria-label="Close">
+        </button>
     </div>
 {% endif %}

--- a/app/templates/app/downloads.html
+++ b/app/templates/app/downloads.html
@@ -12,7 +12,9 @@ Downloads page
 
 {% block subnav %}
     <div class="container-xxl">
-        <h1 class="h3">Data download</h1>
+        <h1 class="h3">
+            Data download
+        </h1>
     </div>
 
     <div class="subnavbar sticky-top py-1">
@@ -34,12 +36,15 @@ Downloads page
                  id="offcanvas"
                  aria-labelledby="bdSidebarOffcanvasLabel">
                 <div class="offcanvas-header border-bottom">
-                    <h5 class="offcanvas-title" id="bdSidebarOffcanvasLabel">Data download</h5>
+                    <h5 class="offcanvas-title" id="bdSidebarOffcanvasLabel">
+                        Data download
+                    </h5>
                     <button type="button"
                             class="btn-close"
                             data-bs-dismiss="offcanvas"
                             aria-label="Close"
-                            data-bs-target="#offcanvas"></button>
+                            data-bs-target="#offcanvas">
+                    </button>
                 </div>
 
                 <div class="offcanvas-body">
@@ -99,18 +104,30 @@ Downloads page
             <table id="species_table" class="display nowrap w-100">
                 <thead>
                     <tr>
-                        <th>Species</th>
-                        <th>Common name</th>
-                        <th>Proteome</th>
-                        <th>DIAMOND database</th>
+                        <th>
+                            Species
+                        </th>
+                        <th>
+                            Common name
+                        </th>
+                        <th>
+                            Proteome
+                        </th>
+                        <th>
+                            DIAMOND database
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
                     {% with file_types="Proteome,DIAMOND" %}
                         {% for species in species_all %}
                             <tr>
-                                <td>{{ species.get_html_link }}</td>
-                                <td>{{ species.common_name|default_if_none:"–" }}</td>
+                                <td>
+                                    {{ species.get_html_link }}
+                                </td>
+                                <td>
+                                    {{ species.common_name|default_if_none:"–" }}
+                                </td>
 
                                 {% for file_type in file_types|split:"," %}
                                     {% with file=species.files.all|get_file_type:file_type %}
@@ -148,23 +165,43 @@ Downloads page
             <table id="dataset_table" class="display nowrap w-100">
                 <thead>
                     <tr>
-                        <th>Dataset name</th>
-                        <th>Species common name</th>
+                        <th>
+                            Dataset name
+                        </th>
+                        <th>
+                            Species common name
+                        </th>
 
-                        <th>Single cell data</th>
-                        <th>Metacell data</th>
-                        <th>Metacell counts</th>
+                        <th>
+                            Single cell data
+                        </th>
+                        <th>
+                            Metacell data
+                        </th>
+                        <th>
+                            Metacell counts
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for dataset in datasets_all %}
                         <tr>
-                            <td>{{ dataset.get_html_link }}</td>
-                            <td>{{ dataset.species.common_name|default_if_none:"–" }}</td>
+                            <td>
+                                {{ dataset.get_html_link }}
+                            </td>
+                            <td>
+                                {{ dataset.species.common_name|default_if_none:"–" }}
+                            </td>
 
-                            <td>{% download_dataset_data view='rest:singlecell-list' slug=dataset.slug suffix='single cells' %}</td>
-                            <td>{% download_dataset_data view='rest:metacell-list' slug=dataset.slug suffix='metacells' %}</td>
-                            <td>{% download_dataset_data view='rest:metacellcount-list' slug=dataset.slug suffix='metacell counts' %}</td>
+                            <td>
+                                {% download_dataset_data view='rest:singlecell-list' slug=dataset.slug suffix='single cells' %}
+                            </td>
+                            <td>
+                                {% download_dataset_data view='rest:metacell-list' slug=dataset.slug suffix='metacells' %}
+                            </td>
+                            <td>
+                                {% download_dataset_data view='rest:metacellcount-list' slug=dataset.slug suffix='metacell counts' %}
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/app/templates/app/entries/dataset_list.html
+++ b/app/templates/app/entries/dataset_list.html
@@ -10,13 +10,21 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Dataset</th>
-    <th>Species common name</th>
+    <th>
+        Dataset
+    </th>
+    <th>
+        Species common name
+    </th>
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td>{{ each.species.common_name|default:'—' }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td>
+        {{ each.species.common_name|default:'—' }}
+    </td>
 {% endblock row %}
 
 {% block unfound %}

--- a/app/templates/app/entries/domain_detail.html
+++ b/app/templates/app/entries/domain_detail.html
@@ -10,25 +10,45 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Gene</th>
-    <th class="entry-description">Description</th>
-    <th>Domains</th>
+    <th>
+        Gene
+    </th>
+    <th class="entry-description">
+        Description
+    </th>
+    <th>
+        Domains
+    </th>
 
     {% if not species %}
-        <th>Species</th>
-        <th>Species common name</th>
+        <th>
+            Species
+        </th>
+        <th>
+            Species common name
+        </th>
     {% endif %}
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td class="entry-description">{{ each.description|default:'—' }}</td>
-    <td>{{ each.get_domain_html_links|default:'—' }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td class="entry-description">
+        {{ each.description|default:'—' }}
+    </td>
+    <td>
+        {{ each.get_domain_html_links|default:'—' }}
+    </td>
 
     {% if not species %}
         {% load entry_links %}
-        <td>{% species_domain_link each.species domain %}</td>
-        <td>{{ each.species.common_name|default:'—' }}</td>
+        <td>
+            {% species_domain_link each.species domain %}
+        </td>
+        <td>
+            {{ each.species.common_name|default:'—' }}
+        </td>
     {% endif %}
 {% endblock row %}
 

--- a/app/templates/app/entries/domain_list.html
+++ b/app/templates/app/entries/domain_list.html
@@ -10,13 +10,21 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Domain</th>
-    <th>Number of genes</th>
+    <th>
+        Domain
+    </th>
+    <th>
+        Number of genes
+    </th>
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td>{{ each.gene_set.count |default:'—' }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td>
+        {{ each.gene_set.count |default:'—' }}
+    </td>
 {% endblock row %}
 
 {% block unfound %}

--- a/app/templates/app/entries/entry.html
+++ b/app/templates/app/entries/entry.html
@@ -12,7 +12,9 @@ Base entry template
 
 {% block content %}
 
-    <h1 class="h3 text-break">BCA database entries</h1>
+    <h1 class="h3 text-break">
+        BCA database entries
+    </h1>
 
     {% load cards %}
     <div class="row row-cols row-cols-sm-2 row-cols-lg-4">

--- a/app/templates/app/entries/gene_detail.html
+++ b/app/templates/app/entries/gene_detail.html
@@ -5,7 +5,9 @@
 {% endblock title %}
 
 {% block content %}
-    <h1 class="h3 text-break">{{ gene }}</h1>
+    <h1 class="h3 text-break">
+        {{ gene }}
+    </h1>
     <div class="row pt-2">
         <div class="col-md-4">
             <p>
@@ -14,19 +16,27 @@
 
             <hr />
 
-            <p>{{ gene.species.get_html_link }}</p>
+            <p>
+                {{ gene.species.get_html_link }}
+            </p>
 
-            <h2 class="h4">BCA datasets</h2>
+            <h2 class="h4">
+                BCA datasets
+            </h2>
             <ul class="list-unstyled">
                 {% load entry_links %}
                 {% for dataset in gene.species.datasets.all %}
-                    <li>{% dataset_gene_link dataset gene %}</li>
+                    <li>
+                        {% dataset_gene_link dataset gene %}
+                    </li>
                 {% endfor %}
             </ul>
         </div>
 
         <div class="col-md-8">
-            <h2 class="h4">Orthogroup</h2>
+            <h2 class="h4">
+                Orthogroup
+            </h2>
 
             <p>
                 {% if gene.orthogroup %}
@@ -36,72 +46,104 @@
                 {% endif %}
             </p>
 
-            <h2 class="h4">Gene lists</h2>
+            <h2 class="h4">
+                Gene lists
+            </h2>
 
             {% if gene.genelists.all %}
                 <table class="table table-sm table-striped">
                     <thead>
                         <tr>
-                            <th>List name</th>
-                            <th>Description</th>
+                            <th>
+                                List name
+                            </th>
+                            <th>
+                                Description
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
                         {% load entry_links %}
                         {% for list in gene.genelists.all %}
                             <tr>
-                                <td>{% get_genelist_link_by_species list gene.species %}</td>
-                                <td>{{ list.description|default:"—" }}</td>
+                                <td>
+                                    {% get_genelist_link_by_species list gene.species %}
+                                </td>
+                                <td>
+                                    {{ list.description|default:"—" }}
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             {% else %}
-                <p>No gene lists.</p>
+                <p>
+                    No gene lists.
+                </p>
             {% endif %}
 
-            <h2 class="h4">Gene modules</h2>
+            <h2 class="h4">
+                Gene modules
+            </h2>
 
             {% if gene.modules.all %}
                 <table class="table table-sm table-striped">
                     <thead>
                         <tr>
-                            <th>Module</th>
-                            <th>Membership score</th>
+                            <th>
+                                Module
+                            </th>
+                            <th>
+                                Membership score
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for module in gene.modules.all %}
                             <tr>
-                                <td>{{ module.get_html_link }}</td>
-                                <td>{{ module.membership_score }}</td>
+                                <td>
+                                    {{ module.get_html_link }}
+                                </td>
+                                <td>
+                                    {{ module.membership_score }}
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             {% else %}
-                <p>No gene modules.</p>
+                <p>
+                    No gene modules.
+                </p>
             {% endif %}
 
-            <h2 class="h4">Protein domains</h2>
+            <h2 class="h4">
+                Protein domains
+            </h2>
 
             {% if gene.domains.all %}
                 <table class="table table-sm table-striped">
                     <thead>
                         <tr>
-                            <th>Domain</th>
+                            <th>
+                                Domain
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for domain in gene.domains.all %}
                             <tr>
-                                <td>{{ domain.get_html_link }}</td>
+                                <td>
+                                    {{ domain.get_html_link }}
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             {% else %}
-                <p>No protein domains.</p>
+                <p>
+                    No protein domains.
+                </p>
             {% endif %}
         </div>
     </div>

--- a/app/templates/app/entries/gene_list.html
+++ b/app/templates/app/entries/gene_list.html
@@ -10,22 +10,42 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Gene</th>
-    <th class="entry-description">Description</th>
-    <th>Domains</th>
+    <th>
+        Gene
+    </th>
+    <th class="entry-description">
+        Description
+    </th>
+    <th>
+        Domains
+    </th>
     {% if not species %}
-        <th>Species</th>
-        <th>Species common name</th>
+        <th>
+            Species
+        </th>
+        <th>
+            Species common name
+        </th>
     {% endif %}
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td class="entry-description">{{ each.description|default:'—' }}</td>
-    <td>{{ each.get_domain_html_links|default:'—' }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td class="entry-description">
+        {{ each.description|default:'—' }}
+    </td>
+    <td>
+        {{ each.get_domain_html_links|default:'—' }}
+    </td>
     {% if not species %}
-        <td>{{ each.species.get_genes_html_link }}</td>
-        <td>{{ each.species.common_name|default:'—' }}</td>
+        <td>
+            {{ each.species.get_genes_html_link }}
+        </td>
+        <td>
+            {{ each.species.common_name|default:'—' }}
+        </td>
     {% endif %}
 {% endblock row %}
 

--- a/app/templates/app/entries/gene_list_detail.html
+++ b/app/templates/app/entries/gene_list_detail.html
@@ -10,25 +10,45 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Gene</th>
-    <th class="entry-description">Description</th>
-    <th>Domains</th>
+    <th>
+        Gene
+    </th>
+    <th class="entry-description">
+        Description
+    </th>
+    <th>
+        Domains
+    </th>
 
     {% if not species %}
-        <th>Species</th>
-        <th>Species common name</th>
+        <th>
+            Species
+        </th>
+        <th>
+            Species common name
+        </th>
     {% endif %}
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td class="entry-description">{{ each.description|default:'—' }}</td>
-    <td>{{ each.get_domain_html_links|default:'—' }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td class="entry-description">
+        {{ each.description|default:'—' }}
+    </td>
+    <td>
+        {{ each.get_domain_html_links|default:'—' }}
+    </td>
 
     {% if not species %}
         {% load entry_links %}
-        <td>{% species_genelist_link each.species gene_list %}</td>
-        <td>{{ each.species.common_name|default:'—' }}</td>
+        <td>
+            {% species_genelist_link each.species gene_list %}
+        </td>
+        <td>
+            {{ each.species.common_name|default:'—' }}
+        </td>
     {% endif %}
 {% endblock row %}
 

--- a/app/templates/app/entries/gene_list_list.html
+++ b/app/templates/app/entries/gene_list_list.html
@@ -10,15 +10,27 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Gene list</th>
-    <th class="entry-description">Description</th>
-    <th>Number of genes</th>
+    <th>
+        Gene list
+    </th>
+    <th class="entry-description">
+        Description
+    </th>
+    <th>
+        Number of genes
+    </th>
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td class="entry-description">{{ each.description|default:'—' }}</td>
-    <td>{{ each.genes.count }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td class="entry-description">
+        {{ each.description|default:'—' }}
+    </td>
+    <td>
+        {{ each.genes.count }}
+    </td>
 {% endblock row %}
 
 {% block unfound %}

--- a/app/templates/app/entries/gene_module_detail.html
+++ b/app/templates/app/entries/gene_module_detail.html
@@ -12,17 +12,33 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Gene</th>
-    <th class="entry-description">Description</th>
-    <th>Domains</th>
-    <th>Membership score</th>
+    <th>
+        Gene
+    </th>
+    <th class="entry-description">
+        Description
+    </th>
+    <th>
+        Domains
+    </th>
+    <th>
+        Membership score
+    </th>
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.gene.get_html_link }}</td>
-    <td class="entry-description">{{ each.gene.description|default:'—' }}</td>
-    <td>{{ each.gene.get_domain_html_links }}</td>
-    <td>{{ each.membership_score }}</td>
+    <td>
+        {{ each.gene.get_html_link }}
+    </td>
+    <td class="entry-description">
+        {{ each.gene.description|default:'—' }}
+    </td>
+    <td>
+        {{ each.gene.get_domain_html_links }}
+    </td>
+    <td>
+        {{ each.membership_score }}
+    </td>
 {% endblock row %}
 
 {% block unfound %}

--- a/app/templates/app/entries/gene_module_list.html
+++ b/app/templates/app/entries/gene_module_list.html
@@ -10,20 +10,36 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Gene module</th>
-    <th>Number of genes</th>
+    <th>
+        Gene module
+    </th>
+    <th>
+        Number of genes
+    </th>
     {% if not dataset %}
-        <th>Dataset</th>
-        <th>Species common name</th>
+        <th>
+            Dataset
+        </th>
+        <th>
+            Species common name
+        </th>
     {% endif %}
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td>{{ each.gene_modules.count }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td>
+        {{ each.gene_modules.count }}
+    </td>
     {% if not dataset %}
-        <td>{{ each.dataset.get_gene_modules_html_link }}</td>
-        <td>{{ each.dataset.species.common_name|default:'—' }}</td>
+        <td>
+            {{ each.dataset.get_gene_modules_html_link }}
+        </td>
+        <td>
+            {{ each.dataset.species.common_name|default:'—' }}
+        </td>
     {% endif %}
 {% endblock row %}
 

--- a/app/templates/app/entries/orthogroup_detail.html
+++ b/app/templates/app/entries/orthogroup_detail.html
@@ -12,19 +12,39 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Gene</th>
-    <th class="entry-description">Description</th>
-    <th>Domains</th>
-    <th>Species</th>
-    <th>Common name</th>
+    <th>
+        Gene
+    </th>
+    <th class="entry-description">
+        Description
+    </th>
+    <th>
+        Domains
+    </th>
+    <th>
+        Species
+    </th>
+    <th>
+        Common name
+    </th>
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.gene.get_html_link }}</td>
-    <td class="entry-description">{{ each.gene.description|default:'—' }}</td>
-    <td>{{ each.gene.get_domain_html_links }}</td>
-    <td>{{ each.gene.species.get_html_link }}</td>
-    <td>{{ each.gene.species.common_name|default:'—' }}</td>
+    <td>
+        {{ each.gene.get_html_link }}
+    </td>
+    <td class="entry-description">
+        {{ each.gene.description|default:'—' }}
+    </td>
+    <td>
+        {{ each.gene.get_domain_html_links }}
+    </td>
+    <td>
+        {{ each.gene.species.get_html_link }}
+    </td>
+    <td>
+        {{ each.gene.species.common_name|default:'—' }}
+    </td>
 {% endblock row %}
 
 {% block unfound %}

--- a/app/templates/app/entries/orthogroup_list.html
+++ b/app/templates/app/entries/orthogroup_list.html
@@ -10,13 +10,21 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Orthogroup</th>
-    <th>Number of orthologs</th>
+    <th>
+        Orthogroup
+    </th>
+    <th>
+        Number of orthologs
+    </th>
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td>{{ each.orthologs.count }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td>
+        {{ each.orthologs.count }}
+    </td>
 {% endblock row %}
 
 {% block unfound %}

--- a/app/templates/app/entries/species_detail.html
+++ b/app/templates/app/entries/species_detail.html
@@ -8,22 +8,34 @@
 
     <h1 class="h3 text-break">
         {{ species.get_html }}
-        {% if species.common_name %}<div class="small text-muted">{{ species.common_name }}</div>{% endif %}
+        {% if species.common_name %}
+            <div class="small text-muted">
+                {{ species.common_name }}
+            </div>
+        {% endif %}
     </h1>
 
     <div class="row pt-2">
         <div class="col-md-4">
-            <p>{% include "../components/dataset_image.html" %}</p>
-            <p>{{ species.description|default:'No description available.'|safe }}</p>
+            <p>
+                {% include "../components/dataset_image.html" %}
+            </p>
+            <p>
+                {{ species.description|default:'No description available.'|safe }}
+            </p>
 
-            <h2 class="h4">Species data</h2>
+            <h2 class="h4">
+                Species data
+            </h2>
             <ul>
                 <li>
                     <a href="{{ species.get_gene_list_url }}">Genes</a>
                 </li>
             </ul>
 
-            <h2 class="h4">Files</h2>
+            <h2 class="h4">
+                Files
+            </h2>
             <ul>
                 {% for file in species.files.all %}
                     <li>
@@ -34,24 +46,40 @@
         </div>
 
         <div class="col-md-8">
-            <h2 class="h4">BCA datasets</h2>
+            <h2 class="h4">
+                BCA datasets
+            </h2>
             <ul class="list-unstyled">
-                {% for dataset in species.datasets.all %}<li>{{ dataset.get_html_link }}</li>{% endfor %}
+                {% for dataset in species.datasets.all %}
+                    <li>
+                        {{ dataset.get_html_link }}
+                    </li>
+                {% endfor %}
             </ul>
 
-            <h2 class="h4">Metadata</h2>
+            <h2 class="h4">
+                Metadata
+            </h2>
             <table class="table table-sm table-striped">
                 <thead>
                     <tr>
-                        <th>Key</th>
-                        <th>Value</th>
-                        <th>Source</th>
+                        <th>
+                            Key
+                        </th>
+                        <th>
+                            Value
+                        </th>
+                        <th>
+                            Source
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for metadata in species.meta_set.all %}
                         <tr>
-                            <td>{{ metadata.label }}</td>
+                            <td>
+                                {{ metadata.label }}
+                            </td>
                             <td>
                                 {% with metadata.get_absolute_url as url %}
                                     {% if url %}
@@ -61,7 +89,9 @@
                                     {% endif %}
                                 {% endwith %}
                             </td>
-                            <td>{{ metadata.source.get_html_link }}</td>
+                            <td>
+                                {{ metadata.source.get_html_link }}
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/app/templates/app/entries/species_list.html
+++ b/app/templates/app/entries/species_list.html
@@ -10,26 +10,52 @@
 {% endblock heading %}
 
 {% block header %}
-    <th>Species</th>
-    <th>Common name</th>
-    <th>Division</th>
-    <th>Kingdom</th>
-    <th>Phylum</th>
-    <th>Datasets</th>
+    <th>
+        Species
+    </th>
+    <th>
+        Common name
+    </th>
+    <th>
+        Division
+    </th>
+    <th>
+        Kingdom
+    </th>
+    <th>
+        Phylum
+    </th>
+    <th>
+        Datasets
+    </th>
 {% endblock header %}
 
 {% block row %}
-    <td>{{ each.get_html_link }}</td>
-    <td>{{ each.common_name|default:"—" }}</td>
+    <td>
+        {{ each.get_html_link }}
+    </td>
+    <td>
+        {{ each.common_name|default:"—" }}
+    </td>
 
-    <td>{{ each.division }}</td>
-    <td>{{ each.kingdom }}</td>
-    <td>{{ each.phylum }}</td>
+    <td>
+        {{ each.division }}
+    </td>
+    <td>
+        {{ each.kingdom }}
+    </td>
+    <td>
+        {{ each.phylum }}
+    </td>
 
     <td>
         {% if each.datasets %}
             <ul class="mb-0 list-unstyled">
-                {% for dataset in each.datasets.all %}<li>{{ dataset.get_html_link }}</li>{% endfor %}
+                {% for dataset in each.datasets.all %}
+                    <li>
+                        {{ dataset.get_html_link }}
+                    </li>
+                {% endfor %}
             </ul>
         {% endif %}
     </td>

--- a/app/templates/app/home.html
+++ b/app/templates/app/home.html
@@ -25,7 +25,9 @@ Features:
 
     {% load static %}
     <div class="px-2 text-center">
-        <h1 class="display-5 fw-bold text-body-emphasis d-none">Biodiversity Cell Atlas: Data Portal</h1>
+        <h1 class="display-5 fw-bold text-body-emphasis d-none">
+            Biodiversity Cell Atlas: Data Portal
+        </h1>
 
         <img title="Biodiversity Cell Atlas"
              width="500"
@@ -54,7 +56,8 @@ Features:
 
     <!-- Tree of Life -->
     <div id="tree"
-         class="container d-flex align-items-center justify-content-center"></div>
+         class="container d-flex align-items-center justify-content-center">
+    </div>
     <script type="module">
         import { createTreeOfLife } from "{% static 'app/js/plots/tree_of_life.js' %}";
         createTreeOfLife("#tree", "{% static 'app/life.json' %}");
@@ -78,7 +81,9 @@ Features:
     <div class="row row-cols-1 row-cols-md-3 align-items-stretch g-4 py-2">
         {% load cards %}
         {% for post in posts.latest %}
-            <div class="col">{% news_card title=post.title date=post.date|date:"j F Y" img_url=post.image link=post.link %}</div>
+            <div class="col">
+                {% news_card title=post.title date=post.date|date:"j F Y" img_url=post.image link=post.link %}
+            </div>
         {% empty %}
             <span class="text-secondary"><i>No posts available.</i></span>
         {% endfor %}

--- a/app/templates/app/reference.html
+++ b/app/templates/app/reference.html
@@ -10,7 +10,9 @@ Reference: documentation, tutorials, etc.
 
     <style>{{ pygments_css|safe }}</style>
 
-    <div class="markdown-content">{{ content|safe }}</div>
+    <div class="markdown-content">
+        {{ content|safe }}
+    </div>
 
 {% endblock %}
 

--- a/app/templates/app/search.html
+++ b/app/templates/app/search.html
@@ -12,7 +12,9 @@ Search page
 
 {% block content %}
 
-    <h1 class="h3 pt-2 mb-3">Search results</h1>
+    <h1 class="h3 pt-2 mb-3">
+        Search results
+    </h1>
 
     <div class="row mb-5">
         <div class="col-6">
@@ -43,14 +45,20 @@ Search page
 
                     <button type="button"
                             class="btn btn-link btn-sm text-start nav-link p-1 {% if not query.category %}active{% endif %}"
-                            onclick="updateQuery('category')">Summary</button>
+                            onclick="updateQuery('category')">
+                        Summary
+                    </button>
                     <button type="button"
                             class="btn btn-link btn-sm text-start nav-link p-1 {% if query.category == 'datasets' %}active{% endif %}"
-                            onclick="updateQuery('category', 'datasets')">Datasets</button>
+                            onclick="updateQuery('category', 'datasets')">
+                        Datasets
+                    </button>
 
                     <button type="button"
                             class="btn btn-link btn-sm text-start nav-link p-1 {% if query.category == 'genes' %}active{% endif %}"
-                            onclick="updateQuery('category', 'genes')">Genes</button>
+                            onclick="updateQuery('category', 'genes')">
+                        Genes
+                    </button>
 
                     <!-- Species selection -->
                     <div class="d-flex justify-content-between mt-3 p-1">
@@ -60,7 +68,9 @@ Search page
 
                         <button type="button"
                                 class="btn btn-link btn-sm"
-                                onclick="updateQuery('species')">Clear</button>
+                                onclick="updateQuery('species')">
+                            Clear
+                        </button>
                     </div>
                     {% include './components/select/species.html' with redirect='query' placeholder='Search...' species=query.species %}
 
@@ -90,8 +100,10 @@ Search page
                                 <p class="mb-0 small">
                                     <a href="#" class="result-subtitle text-secondary"></a>
                                 </p>
-                                <p class="mb-0 truncate-3 small result-description"></p>
-                                <p class="mb-0 small result-badges"></p>
+                                <p class="mb-0 truncate-3 small result-description">
+                                </p>
+                                <p class="mb-0 small result-badges">
+                                </p>
                             </div>
                         </div>
                     </template>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,7 +20,9 @@ Dynamic blocks:
 <html lang="en">
     <head>
         <title>
-            {% block title %}Biodiversity Cell Atlas: Data Portal{% endblock %}
+            {% block title %}
+                Biodiversity Cell Atlas: Data Portal
+            {% endblock %}
         </title>
 
         <meta name="description"
@@ -130,9 +132,12 @@ Dynamic blocks:
         {% endblock subnav %}
 
         <main class="container-xxl overflow-x-clip">
-            {% block breadcrumb %}{% endblock %}
-            {% block content %}{% endblock %}
-            {% block pagination %}{% endblock %}
+            {% block breadcrumb %}
+            {% endblock %}
+            {% block content %}
+            {% endblock %}
+            {% block pagination %}
+            {% endblock %}
         </main>
 
         {% block footer %}

--- a/app/templates/error_page.html
+++ b/app/templates/error_page.html
@@ -18,17 +18,20 @@
                     <figcaption class="text-center small text-muted">
                         Photo by
                         <a href="{% block author_url %}{% endblock %}" target="_blank">
-                            {% block author %}{% endblock %}
+                            {% block author %}
+                            {% endblock %}
                         </a>
                     </figcaption>
                 </figure>
             </div>
             <div class="col align-self-center">
                 <h1 class="h3">
-                    {% block title %}{% endblock %}
+                    {% block title %}
+                    {% endblock %}
                 </h1>
                 <p>
-                    {% block description %}{% endblock %}
+                    {% block description %}
+                    {% endblock %}
                 </p>
             </div>
         </div>

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -58,7 +58,8 @@ Features:
             </a>
         </div>
 
-        <div class="mb-3 d-none d-md-block"></div>
+        <div class="mb-3 d-none d-md-block">
+        </div>
 
         <div class="mb-3">
             <h6>

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -119,11 +119,14 @@ Features:
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header background-light-accent">
-                <h1 class="modal-title fs-5 text-black-50" id="demoModalLabel">BCA Demo release</h1>
+                <h1 class="modal-title fs-5 text-black-50" id="demoModalLabel">
+                    BCA Demo release
+                </h1>
                 <button type="button"
                         class="btn-close"
                         data-bs-dismiss="modal"
-                        aria-label="Close"></button>
+                        aria-label="Close">
+                </button>
             </div>
             <div class="modal-body">
                 <p>


### PR DESCRIPTION
Enable [`line_break_after_multiline_tag`](https://djlint.com/docs/configuration/#line-break-after-multiline-tag):

> Do not condense the content of multi-line tags into the line of the last attribute.