### PR TITLE
Improve speed of JSON serialisation

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -10,8 +10,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
-import os
 from pathlib import Path
+import orjson
+import os
 import secrets
 
 from .pre_settings import get_diamond_version, get_env, get_latest_git_tag
@@ -189,10 +190,15 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest.pagination.StandardPagination",
     "DEFAULT_RENDERER_CLASSES": [
-        "rest_framework.renderers.JSONRenderer",
+        "drf_orjson_renderer.renderers.ORJSONRenderer",
         "rest.renderers.CSVRenderer",
         "rest.renderers.TSVRenderer",
     ],
+    "ORJSON_RENDERER_OPTIONS": (
+        orjson.OPT_NON_STR_KEYS,
+        orjson.OPT_SERIALIZE_DATACLASS,
+        orjson.OPT_SERIALIZE_NUMPY,
+    ),
 }
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,10 +10,11 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
-from pathlib import Path
-import orjson
 import os
+from pathlib import Path
 import secrets
+
+import orjson
 
 from .pre_settings import get_diamond_version, get_env, get_latest_git_tag
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Pygments==2.19.2
 djangorestframework==3.16.1
 django-filter==25.1
 drf-spectacular==0.28.0
+drf-orjson-renderer==1.7.3
 
 # Monitoring
 django-prometheus==2.4.1


### PR DESCRIPTION
[drf-orjson-renderer](https://pypi.org/project/drf-orjson-renderer/) simplifies using [orjson](https://pypi.org/project/orjson/) in Django for JSON serialisation of the API responses. This improves the speed of JSON serialisation.