### PR TITLE
Generate sitemaps XML

### DIFF
--- a/app/sitemaps.py
+++ b/app/sitemaps.py
@@ -1,0 +1,37 @@
+"""Create sitemaps."""
+
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+from . import models
+
+class AtlasSitemap(Sitemap):
+    """Sitemap for Cell Atlas pages."""
+    changefreq = "weekly"
+    priority = 0.8
+
+    def items(self):
+        """Return list of species to include in the sitemap."""
+        return models.Dataset.objects.all()
+
+    def location(self, obj):
+        """Return the URL for the main page of a species."""
+        return reverse('atlas_info', args=[obj.slug])
+
+    def lastmod(self, obj):
+        """
+        Return last modified date for the species page.
+        Useful to state last update to search engines.
+        """
+        return obj.date_updated
+
+
+class StaticViewSitemap(Sitemap):
+    """Sitemap for static pages."""
+    changefreq = "monthly"
+    priority = 0.5
+
+    def items(self):
+        return ['atlas', 'downloads', 'about', 'entry', 'reference', 'api']
+
+    def location(self, item):
+        return reverse(item)

--- a/app/urls.py
+++ b/app/urls.py
@@ -4,8 +4,15 @@ downloads, search, health check, and custom error pages.
 """
 
 from django.urls import path
+from django.contrib.sitemaps.views import sitemap
+from .sitemaps import StaticViewSitemap, AtlasSitemap
 
 from . import views
+
+sitemaps = {
+    'static': StaticViewSitemap,
+    'dataset': AtlasSitemap,
+}
 
 urlpatterns = [
     path("", views.IndexView.as_view(), name="index"),
@@ -119,6 +126,8 @@ urlpatterns = [
     path("about/", views.AboutView.as_view(), name="about"),
     path("search/", views.SearchView.as_view(), name="search"),
     path("health/", views.HealthView.as_view(), name="health"),
+    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
+
     # Error pages
     path("403/", views.Custom403View.as_view()),
     path("404/", views.Custom404View.as_view()),

--- a/config/settings.py
+++ b/config/settings.py
@@ -49,6 +49,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 ALLOWED_HOSTS = get_env("DJANGO_ALLOWED_HOSTS", "", type="array")
 DEBUG = get_env("DJANGO_DEBUG", type="bool")
 SECRET_KEY = get_env("DJANGO_SECRET_KEY")
+SITE_ID = 1
 
 if get_env("ENVIRONMENT") == "prod":
     # Production environment
@@ -76,6 +77,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
+    "django.contrib.sitemaps",
     "rest_framework",
     "django_filters",
     "colorfield",


### PR DESCRIPTION
Google already crawls the website pretty well. What is the point of having a quite manual way to do this?

Should we avoid `/api/` crawling by using a `robots.txt`?

```
User-agent: *
Disallow: /api/
```