### PR TITLE
Add vertical rules to heatmap

### DIFF
--- a/app/static/app/js/plots/expression_heatmap.js
+++ b/app/static/app/js/plots/expression_heatmap.js
@@ -87,7 +87,12 @@ export function createExpressionHeatmap(id, species, data) {
                                 type: "quantitative",
                                 title: "Log\u2082 FC",
                                 scale: {
-                                    range: ["#F2F2F2", "#FFA500", "#EE4000", "#520c52"],
+                                    range: [
+                                        "#F2F2F2",
+                                        "#FFA500",
+                                        "#EE4000",
+                                        "#520c52",
+                                    ],
                                 },
                             },
                         },
@@ -98,29 +103,39 @@ export function createExpressionHeatmap(id, species, data) {
                             // Filter first value for each metacell type
                             {
                                 window: [{ op: "row_number", as: "rn" }],
-                                groupby: [ "metacell_type" ],
-                                sort: [{ field: "metacell_name", order: "ascending" }]
+                                groupby: ["metacell_type"],
+                                sort: [
+                                    {
+                                        field: "metacell_name",
+                                        order: "ascending",
+                                    },
+                                ],
                             },
                             {
-                                filter: "datum.rn === 1"
+                                filter: "datum.rn === 1",
                             },
 
                             // Discard first value (overlaps the Y-axis grid line)
                             {
-                                "window": [{ "op": "row_number", "as": "rn_all" }],
-                                "sort": [{ "field": "metacell_name", "order": "ascending" }]
+                                window: [{ op: "row_number", as: "rn_all" }],
+                                sort: [
+                                    {
+                                        field: "metacell_name",
+                                        order: "ascending",
+                                    },
+                                ],
                             },
                             {
-                                "filter": "datum.rn_all > 1"
-                            }
+                                filter: "datum.rn_all > 1",
+                            },
                         ],
                         encoding: {
                             // Position first mark to the left
                             x: { field: "metacell_name", bandPosition: 0 },
                             color: { value: "gray" },
-                            strokeWidth: { value: 0.5 }
-                        }
-                    }
+                            strokeWidth: { value: 0.5 },
+                        },
+                    },
                 ],
             },
             {


### PR DESCRIPTION
# Changelog

- For every unique metacell type in the heatmap, add a vertical rule to help guide users.

# Screenshot

<img width="1283" height="654" alt="Screenshot 2025-10-23 at 16 11 06" src="https://github.com/user-attachments/assets/aac091bf-1387-4cec-95f8-b907ce580f21" />

# Affected pages

> [!TIP]
> If the plot is not showing correctly, refresh JavaScript files by restarting the project with `podman compose` and/or cleaning browser cache.

- [Overview heatmap expression](http://portal.localhost/atlas/nematostella-vectensis/overview/#expression)
- [Gene lists](http://portal.localhost/atlas/nematostella-vectensis/panel/?gene_lists=Ank_2&fc_min=2&clip_log2=6&metacell_lists=&genes=Ank_2#expression)