### PR TITLE
Django CI: fail if database migrations are missing

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -52,11 +52,6 @@ jobs:
                   docker compose exec web \
                       python manage.py makemigrations --check
 
-            - name: Install coverage
-              run: |
-                  docker compose exec web \
-                      pip install coverage
-
             - name: Run tests with coverage
               run: |
                   docker compose exec web \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Django==5.2.9
 django-colorfield==0.14.0
 gunicorn==23.0.0
+h5py==3.15.1
 
 # Blog parsing
 beautifulsoup4==4.14.3
@@ -21,6 +22,7 @@ drf-orjson-renderer==1.7.3
 django-prometheus==2.4.1
 
 # dev
+coverage==7.13.0
 django-debug-toolbar==5.2.0
 django-extensions==4.1
 pandas==2.3.3
@@ -28,5 +30,3 @@ psutil==7.1.3
 psycopg2==2.9.11
 rds2py==0.8.0
 scipy==1.16.3
-h5py==3.15.1
-


### PR DESCRIPTION
# Changes

* Fail if database migrations are missing
    * Failure test: https://github.com/biodiversitycellatlas/bca-website/pull/168
* Skip deployment check if earlier steps fail
* Add `coverage` to `requirements.txt` for local use and version pinning