### PR TITLE
Fix consortium citation

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -247,19 +247,29 @@ class Publication(ExternalQueryMixin, models.Model):
     doi = models.CharField(max_length=255, unique=True, help_text="DOI (Digital Object Identifier).")
     pmid = models.CharField(max_length=20, unique=True, help_text="PubMed identifier.")
 
+    def format_author_name(self, author):
+        """Return full name for groups, last name for people."""
+        name = author.strip()
+
+        # Check if author is a collective
+        group_keywords = {"consortium", "committee", "group", "team", "collaboration", "project"}
+        if not set(name.lower().split()) & group_keywords:
+            name = name.split()[-1]
+        return name
+
     def create_short_citation(self):
         """Return a condensed in-line citation like 'Darwin et al., 2017'."""
         if self.authors == "":
             return f"Unknown, {self.year}"
 
-        # Get last name of first author
+        # Format name of first author
         authors = self.authors.split(",")
-        first = authors[0].split()[-1]
+        first = self.format_author_name(authors[0])
         if len(authors) == 1:
             citation = f"{first}, {self.year}"
         elif len(authors) == 2:
-            # Get last name of second author
-            second = authors[1].split()[-1]
+            # Format name of second author
+            second = self.format_author_name(authors[1])
             citation = f"{first} & {second}, {self.year}"
         else:
             citation = f"{first} et al., {self.year}"

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -74,6 +74,15 @@ class PublicationModelTest(TestCase):
             doi="10.1016/0022-2836(78)90346-7",
         )
 
+        cls.mouse = Publication.objects.create(
+            title="Single-cell transcriptomics of 20 mouse organs creates a Tabula Muris",
+            authors="The Tabula Muris Consortium",
+            year=2018,
+            journal="Nature",
+            pmid=30283141,
+            doi="10.1038/s41586-018-0590-4",
+        )
+
         cls.standards = Publication.objects.create(
             title="2021 Infusion Therapy Standards of Practice Updates",
             year=2021,
@@ -86,11 +95,13 @@ class PublicationModelTest(TestCase):
         self.assertEqual(self.dna.create_short_citation(), "Watson & Crick, 1953")
         self.assertEqual(self.proteins.create_short_citation(), "Dayhoff, 1976")
         self.assertEqual(self.genetic_code.create_short_citation(), "Sanger et al., 1978")
+        self.assertEqual(self.mouse.create_short_citation(), "The Tabula Muris Consortium, 2018")
         self.assertEqual(self.standards.create_short_citation(), "Unknown, 2021")
 
     def test_string_representation(self):
-        self.assertEqual(str(self.dna), "Watson & Crick, 1953")
-        self.assertEqual(str(self.proteins), "Dayhoff, 1976")
+        self.assertEqual(str(self.dna), self.dna.create_short_citation())
+        self.assertEqual(str(self.proteins), self.proteins.create_short_citation())
+        self.assertEqual(str(self.mouse), self.mouse.create_short_citation())
 
     def test_get_source_html_link(self):
         self.assertEqual(


### PR DESCRIPTION
## Changes 
* Fix short citation when citing a consortium, instead of showing last name as for individuals.
* Add unit tests.

This issue affects the mouse dataset whose publication was written by a consortium:
🔴 Wrong: **Consortium, 2018**
🟢 Fixed: **The Tabula Muris Consortium, 2018**

## Example Link
🔴 Wrong: https://bca-dev.hpc.crg.es/entry/dataset/

## Screenshot
<img width="836" height="226" alt="image" src="https://github.com/user-attachments/assets/48019585-f469-4e59-891a-4751310e26d8" />
