### PR TITLE
Automate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,9 +12,12 @@ changelog:
         - title: 📚 Documentation
           labels:
               - documentation
+        - title: 🤖 Automation
+          labels:
+              - automation
         - title: 📦 Dependencies
           labels:
               - dependencies
-        - title: ⚡ Other changes
+        - title: 📌 Other changes
           labels:
               - "*"


### PR DESCRIPTION
Automates grouping of release notes based on PR labels.
* [Official GitHub docs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

## Future PR

Maybe add automatic labels to PRs depending on files changed or PR title/description. Examples:

| Label | Condition |
|--------|--------|
| `bug` | PR whose title/description mentions `bug` or `fix` |
| `documentation` | File changes in `app/static/docs` |
| `automation` | File changes in `.github` |
| `dependencies ` | Automatically labelled by Dependabot |

> [!NOTE]
> If a PR has multiple labels, only the first matching group in the file is used.