### PR TITLE
Fix Docker ARM build by removing `rds2py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
   "djlint==1.36.4",
   "pandas==3.0.2",
   "psutil==7.2.2",
-  "rds2py==0.9.0",
   "scipy==1.17.1",
   "psycopg[binary,pool]==3.3.3"
 ]


### PR DESCRIPTION
The `rds2py` Python package must be built from source on ARM platforms. Since moving to Docker Hardened images, building it now requires installing additional tooling that we do not otherwise need.

Because `rds2py` is only used to load data from RDS files into the database (which will be phased out), we can remove the dependency altogether.