### PR TITLE
Update categories for release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,12 +12,9 @@ changelog:
         - title: 🦉 Documentation
           labels:
               - documentation
-        - title: 🦫 Infrastructure
+        - title: 🐝 Infrastructure
           labels:
               - infrastructure
-        - title: 🐝 Automation
-          labels:
-              - automation
         - title: 🪸 Dependencies
           labels:
               - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,23 +1,26 @@
 changelog:
     categories:
-        - title: ✨ Features
+        - title: 🐣 Features
           labels:
               - feature
-        - title: 🛠️ Enhancements
+        - title: 🌸 Enhancements
           labels:
               - enhancement
         - title: 🐞 Bug fixes
           labels:
               - bug
-        - title: 📚 Documentation
+        - title: 🦉 Documentation
           labels:
               - documentation
-        - title: 🤖 Automation
+        - title: 🦫 Infrastructure
+          labels:
+              - infrastructure
+        - title: 🐝 Automation
           labels:
               - automation
-        - title: 📦 Dependencies
+        - title: 🪸 Dependencies
           labels:
               - dependencies
-        - title: 📌 Other changes
+        - title: 🦎 Other changes
           labels:
               - "*"


### PR DESCRIPTION
## Changes

Improve release notes automation:
- Change `automation` category to `infrastructure`
- In the spirit of biodiversity, use emojis of living beings to illustrate each category
