### PR TITLE
REST: Simplify GOATOOLS log silencing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "drf-orjson-renderer==1.8.0",
 
   # GO enrichment
-  "GOATOOLS==1.6.4",
+  "GOATOOLS==1.6.5",
   "scikit-learn==1.8.0",
 
   # Monitoring

--- a/rest/services/go_enrichment.py
+++ b/rest/services/go_enrichment.py
@@ -1,6 +1,5 @@
 """GO enrichment analysis."""
 
-import os
 import gzip
 import random
 import math
@@ -40,20 +39,9 @@ class GeneOntologyEnrichmentService:
         self.qvalue = qvalue
 
         # Silently prepare GO enrichment analysis
-        with open(os.devnull, "w") as devnull:
-            old_out = os.dup(1)
-            old_err = os.dup(2)
-
-            os.dup2(devnull.fileno(), 1)
-            os.dup2(devnull.fileno(), 2)
-
-            try:
-                self.gostudy = GOEnrichmentStudy(
-                    background_genes, gene2go, self.obodag, methods=methods, alpha=self.qvalue, log=None, prt=None
-                )
-            finally:
-                os.dup2(old_out, 1)
-                os.dup2(old_err, 2)
+        self.gostudy = GOEnrichmentStudy(
+            background_genes, gene2go, self.obodag, methods=methods, alpha=self.qvalue, log=None
+        )
 
     def run(self, query_genes, sort=False):
         """Calculate GO enrichment and semantic similarity."""


### PR DESCRIPTION
Requires GOATOOLS 1.6.5 where log silencing was simplified: https://github.com/tanghaibao/goatools/pull/340

## Test

Easy way to check log silencing is by running the unit tests:
```bash
podman compose exec web coverage run manage.py test
```

If using GOATOOLS 1.6.5, the following GOATOOLS output will NOT be printed:

```bash
Load  Ontology Enrichment Analysis ...
Propagating term counts 276 GO IDs NOT FOUND IN ASSOCIATION: GO:0019441 GO:0015103 (...)
up: is_a
100%     95 of     95 population items found in association
```