### PR TITLE
Dependabot: ignore Postgres and non-LTS Django updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ registries:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
         replaces-base: true
+
 updates:
     - package-ecosystem: "pip"
       directory: "/"
@@ -13,6 +14,10 @@ updates:
           interval: "weekly"
       cooldown:
           default-days: 7
+      ignore:
+          # Ignore non-LTS Django updates
+          - dependency-name: "django"
+            versions: ["[6.0,6.2)", "[7.0,7.2)"]
 
     - package-ecosystem: "bun"
       directory: "/"
@@ -29,6 +34,8 @@ updates:
           interval: "weekly"
       cooldown:
           default-days: 7
+      ignore:
+          - dependency-name: "postgres"
 
     - package-ecosystem: "docker-compose"
       registries:
@@ -38,6 +45,8 @@ updates:
           interval: "weekly"
       cooldown:
           default-days: 7
+      ignore:
+          - dependency-name: "postgres"
 
     - package-ecosystem: "github-actions"
       directory: "/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Get postgreSQL client
-FROM dhi.io/postgres:18.4-debian13-dev AS postgres
+FROM dhi.io/postgres:18.1-debian13-dev AS postgres
 
 # Get diamond aligner
 FROM buchfink/diamond:version2.1.24 AS diamond


### PR DESCRIPTION
## Changes

- Revert Postgres Docker image to `18.1` to match the production environment.
- Update Dependabot configuration:
  - Restrict Django updates to [LTS releases](https://www.djangoproject.com/download/) (minor version `.2`, e.g. 5.2, 6.2, 7.2).
  - Ignore Postgres dependency updates.