### PR TITLE
Dependabot: Fix ignored Django versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       ignore:
           # Ignore non-LTS Django updates
           - dependency-name: "django"
-            versions: ["[6.0,6.2)", "[7.0,7.2)"]
+            versions: [">= 6.0, < 6.2", ">= 7.0, < 7.2"]
 
     - package-ecosystem: "bun"
       directory: "/"


### PR DESCRIPTION
Dependabot config is currently complaining in https://github.com/biodiversitycellatlas/bca-website/network/updates:

> Your .github/dependabot.yml contained invalid details
>
> Dependabot encountered the following error when parsing your `.github/dependabot.yml`:
>
> ```
> The property '#/updates/0/ignore/0/versions' includes invalid version requirements for a pip ignore condition
> ```
> Please update the config file to conform with Dependabot's specification.
>
> [Learn more](https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependabot-version-updates)

As such, this PR fixes the version range used to ignore pip modules.
Unfortunately, there is no easy way to validate Dependabot configs before merging them.