### PR TITLE
Dependabot: update Docker dependencies for Ghost

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,9 @@ updates:
     - package-ecosystem: "docker"
       registries:
           - dhi
-      directory: "/"
+      directories:
+          - "/"
+          - "/ghost"
       schedule:
           interval: "weekly"
       cooldown:


### PR DESCRIPTION
Dependabot is not suggesting updates for the Ghost Docker image.

This PR configures Dependabot to search for Dockerfiles in specified directories. Based on [Dependabot docs](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files).