### PR TITLE
Dependabot: improve Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM docker.io/buchfink/diamond:version2.1.24 AS diamond
 FROM dhi.io/bun:1-debian13-dev AS bun
 
 # Builder and development
-FROM  dhi.io/python:3.14.6-debian13-dev AS dev
+FROM dhi.io/python:3.14.6-debian13-dev AS dev
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy tools and libraries
 COPY --from=bun /usr/local/bin/bun* /usr/bin/
 COPY --from=diamond /usr/local/bin/diamond /usr/bin/
-COPY --from=postgres  /opt/postgresql/18/bin/* /usr/bin/
+COPY --from=postgres /opt/postgresql/18/bin/* /usr/bin/
 COPY --from=postgres /opt/postgresql/18/lib/libpq.so* /usr/lib/
 RUN arch="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
     cp -a /usr/lib/${arch}/libpcre2* /usr/lib/ && \
@@ -103,11 +103,11 @@ COPY --from=dev /usr/lib/libnettle* /usr/lib/
 COPY --from=dev /usr/lib/libnghttp2* /usr/lib/
 COPY --from=dev /usr/lib/libnghttp3* /usr/lib/
 COPY --from=dev /usr/lib/libp11-kit* /usr/lib/
-COPY --from=dev /usr/lib/libpcre2*  /usr/lib/
+COPY --from=dev /usr/lib/libpcre2* /usr/lib/
 COPY --from=dev /usr/lib/libpsl* /usr/lib/
 COPY --from=dev /usr/lib/librtmp* /usr/lib/
 COPY --from=dev /usr/lib/libsasl2* /usr/lib/
-COPY --from=dev /usr/lib/libselinux*  /usr/lib/
+COPY --from=dev /usr/lib/libselinux* /usr/lib/
 COPY --from=dev /usr/lib/libssh2* /usr/lib/
 COPY --from=dev /usr/lib/libtasn1* /usr/lib/
 COPY --from=dev /usr/lib/libunistring* /usr/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ FROM  dhi.io/python:3.14.6-debian13-dev AS dev
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl=8.14.1-2+deb13u3 \
-    dpkg-dev=1.22.22 \
-    git=1:2.47.3-0+deb13u1 \
+    curl=8.14.* \
+    dpkg-dev=1.22.* \
+    git=1:2.47.* \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy tools and libraries

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM dhi.io/postgres:18.1-debian13-dev AS postgres
 
 # Get diamond aligner
-FROM buchfink/diamond:version2.1.24 AS diamond
+FROM docker.io/buchfink/diamond:version2.1.24 AS diamond
 
 # Get bun
 FROM dhi.io/bun:1-debian13-dev AS bun

--- a/compose.yml
+++ b/compose.yml
@@ -40,7 +40,7 @@ services:
             - mail__transport=${GHOST_MAIL_TRANSPORT}
 
     mailpit:
-        image: axllent/mailpit:v1.29.5
+        image: docker.io/axllent/mailpit:v1.29.5
         env_file: [.env]
         container_name: mailpit
         restart: unless-stopped

--- a/ghost/Dockerfile
+++ b/ghost/Dockerfile
@@ -1,7 +1,7 @@
 # checkov:skip=CKV_DOCKER_2 "Healthcheck should come from Ghost"
 # checkov:skip=CKV_DOCKER_3 "Skip user check"
 
-FROM ghost:6.4-alpine
+FROM docker.io/ghost:6.4-alpine
 
 # Build argument for Plausible URL
 ARG PLAUSIBLE_SCRIPT_URL


### PR DESCRIPTION
* [Fix Dependabot checks for Docker Hub images](https://github.com/biodiversitycellatlas/bca-website/commit/9ef57fea44752741cb3286afdee0c7f21994d151): updates for some Docker images are currently checked in the dhi.io registry only (like Mailpit and Ghost); this change explicitly states the registry of non-DHI images so Dependabot can look for their updates in Docker Hub.
* [Pin Linux dependencies in Dockerfile based on `major.minor` version](https://github.com/biodiversitycellatlas/bca-website/commit/6905c9a9edf545c9bec22c86e410cb9aeca8f274): prevents Linux dependency issues for newer Python images (should we just pin the major version?)
* [Trim consecutive spaces](https://github.com/biodiversitycellatlas/bca-website/commit/d021d08dd21edfba9865914a015206a63a03a564)