### PR TITLE
Dependabot: resolve Docker Hub and dhi.io images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
 version: 2
 registries:
+    dockerhub:
+        type: docker-registry
+        url: https://registry.hub.docker.com
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
     dhi:
         type: docker-registry
         url: https://dhi.io
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        replaces-base: true
 
 updates:
     - package-ecosystem: "pip"
@@ -29,6 +34,7 @@ updates:
     - package-ecosystem: "docker"
       registries:
           - dhi
+          - dockerhub
       directories:
           - "/"
           - "/ghost"
@@ -42,6 +48,7 @@ updates:
     - package-ecosystem: "docker-compose"
       registries:
           - dhi
+          - dockerhub
       directory: "/"
       schedule:
           interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,8 @@ updates:
 
     - package-ecosystem: "docker"
       registries:
-          - dhi
           - dockerhub
+          - dhi
       directories:
           - "/"
           - "/ghost"
@@ -47,8 +47,8 @@ updates:
 
     - package-ecosystem: "docker-compose"
       registries:
-          - dhi
           - dockerhub
+          - dhi
       directory: "/"
       schedule:
           interval: "weekly"


### PR DESCRIPTION
Dependabot is still only resolving to the dhi.io registry, hopefully this PR fixes that.