### PR TITLE
REST: enhance gene search selection and improve endpoints

### DIFF
--- a/app/management/commands/createtestdb.py
+++ b/app/management/commands/createtestdb.py
@@ -46,7 +46,7 @@ def setup_test_environment():
 def create_tgrm_extension():
     """Installs the pg_trm search extension"""
     with connection.cursor() as cursor:
-        cursor.execute("create extension pg_trgm;")
+        cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
 
 
 class Command(BaseCommand):

--- a/app/migrations/0014_trigram_extension.py
+++ b/app/migrations/0014_trigram_extension.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app', '0013_go_annotation'),
+    ]
+
+    operations = [
+        migrations.RunSQL("CREATE EXTENSION IF NOT EXISTS pg_trgm;"),
+    ]

--- a/app/static/app/src/select/gene.ts
+++ b/app/static/app/src/select/gene.ts
@@ -20,8 +20,8 @@ function displayGeneInfo(item, escape) {
         // Display gene lists
         return `
             <div class='option'>
-                ${escape(item.gene)}
-                <span class="text-muted small">${escape(item.count)} genes</span>
+                ${escape(item.name)}
+                <span class="text-muted small">${escape(item.gene_count)} genes</span>
             </div>
         `;
     } else {
@@ -44,7 +44,7 @@ function displayGeneInfo(item, escape) {
                     <span class="text-muted small">
                         ${escape(item.description)}
                     </span>`;
-        return `<div class='option'>${escape(item.gene)} ${desc} ${badges}</div>`;
+        return `<div class='option'>${escape(item.name)} ${desc} ${badges}</div>`;
     }
 }
 
@@ -61,40 +61,39 @@ function displayGeneName(item, escape) {
         // Show count as a badge
         badges = `
             <span class="badge rounded-pill text-bg-secondary">
-                <small>${escape(item.count)}</small>
+                <small>${escape(item.gene_count)}</small>
             </span>
         `;
     }
-    return `<div class='option'>${escape(item.gene)}${badges}</div>`;
+    return `<div class='option'>${escape(item.name)}${badges}</div>`;
 }
 
 /**
- * Prepend gene lists and domains to TomSelect options.
+ * Prepend gene lists, modules and domains to TomSelect options.
  *
  * @param {string} id - Element ID prefix.
  * @param {object} select - TomSelect instance.
  * @param {function} callback - Function to call with options.
- * @param {array} genes - Array of gene objects.
- * @param {array} domains - Array of domain objects.
- * @param {array} preset - Array of preset gene list objects.
+ * @param {array} data - Object with array of genes, modules, lists and domains.
  */
-function prependGeneLists(id, select, callback, genes, domains, preset) {
+function prependGeneLists(id, select, callback, data) {
     const res = getAllLists(`${id}_gene_lists`)
+        .concat(data.gene_lists.map((obj) => ({ ...obj, group: "preset" })))
         .concat(
-            preset.map((obj) => ({
+            data.gene_modules.map((obj) => ({
                 ...obj,
-                count: obj.gene_count,
-                group: "preset",
+                name: obj.module,
+                group: "modules",
             })),
         )
+        .concat(data.domains.map((obj) => ({ ...obj, group: "domains" })))
         .concat(
-            domains.map((obj) => ({
+            data.genes.map((obj) => ({
                 ...obj,
-                count: obj.gene_count,
-                group: "domains",
+                name: obj.gene,
+                group: "genes",
             })),
-        )
-        .concat(genes.map((obj) => ({ ...obj, group: "genes" })));
+        );
     callback(res);
 }
 
@@ -102,19 +101,14 @@ function prependGeneLists(id, select, callback, genes, domains, preset) {
  * Add a default gene to select input and set it as current.
  *
  * @param {string} select - Select element.
- * @param {string} gene - Gene name.
+ * @param {string} name - Gene name.
  * @param {string} description - Gene description.
  * @param {array} domains - Array of gene domains.
  */
-function setDefaultGene(select, gene, description, domains) {
-    const geneOptions = {
-        gene: gene,
-        description: description,
-        domains: domains,
-    };
-
+function setDefaultGene(select, name, description, domains) {
+    const geneOptions = { name, description, domains };
     select.addOption(geneOptions);
-    select.setValue(gene);
+    select.setValue(name);
 }
 
 /**
@@ -140,7 +134,7 @@ function initGeneSelectValues(select, items) {
             for (const i in missingValues) {
                 const elem = missingValues[i];
                 missingValuesArray.push({
-                    gene: elem,
+                    name: elem,
                     description: "",
                     domains: [],
                 });
@@ -159,6 +153,7 @@ function initGeneSelectValues(select, items) {
         const labelMap = {
             preset: "Preset gene lists",
             custom: "Custom gene lists",
+            modules: "Gene modules",
             genes: "Genes",
             domains: "Domains",
         };
@@ -182,7 +177,8 @@ function initGeneSelectValues(select, items) {
  * @param {object} gene - Current gene object.
  * @param {string} selected - Preselected genes (comma-separated).
  * @param {number} limit - Maximum results to load from server.
- * @param {boolean} multiple - Allow multiple selection.
+ * @param {boolean} multiple - Allow multiple selection. If "true", also allows the user
+ *     to select gene lists and domains.
  * @param {boolean} display - Toggle detailed info display.
  */
 export function initGeneSelect(
@@ -200,7 +196,7 @@ export function initGeneSelect(
     const select = new TomSelect(`#${id}_gene_selection`, {
         onChange: function (value) {
             // Avoid jumping if value is empty or matches current gene
-            if (value !== "" && value !== gene.gene) {
+            if (value !== "" && value !== gene.name) {
                 if (redirect == "arg") {
                     const url = getViewUrl("atlas_gene", {
                         dataset,
@@ -228,7 +224,7 @@ export function initGeneSelect(
             onBlur: function () {
                 // Set current gene if no value is selected
                 if (!this.getValue()) {
-                    this.setValue(gene.gene);
+                    this.setValue(gene.name);
                 }
             },
             onType: function () {
@@ -241,56 +237,32 @@ export function initGeneSelect(
             item: display ? displayGeneInfo : displayGeneName,
             option: displayGeneInfo,
         },
-        valueField: "gene",
-        searchField: ["gene", "description", "domains"],
+        valueField: "name",
+        searchField: ["name", "description", "domains"],
         respect_word_boundaries: false,
         preload: true,
         plugins: {
             ...(multiple === "true" && { remove_button: { label: " ×" } }),
         },
         load: function (query, callback) {
-            const genes = $.ajax({
-                url: getViewUrl("rest:gene-list"),
-                data: {
-                    species: species,
-                    q: query || gene,
-                    limit: limit,
-                },
-            });
+            // Use gene search endpoint to return gene lists, modules, and domains
+            const url = getViewUrl(
+                multiple ? "rest:genesearch-list" : "rest:gene-list",
+            );
 
-            const preset = $.ajax({
-                url: getViewUrl("rest:genelist-list"),
-                data: {
-                    species: species,
-                    limit: limit,
-                },
-            });
+            const q = query || gene;
+            const data = { species, dataset, q, limit };
 
-            const domains = multiple
-                ? $.ajax({
-                      url: getViewUrl("rest:domain-list"),
-                      data: {
-                          species: species,
-                          q: query || gene,
-                          limit: 10,
-                          order_by_gene_count: true,
-                      },
-                  })
-                : undefined;
-
-            Promise.all([genes, domains, preset])
-                .then((data) => {
+            $.ajax({ url, data })
+                .then((res) => {
                     if (multiple) {
-                        prependGeneLists(
-                            id,
-                            this,
-                            callback,
-                            data[0].results,
-                            data[1].results,
-                            data[2].results,
-                        );
+                        prependGeneLists(id, this, callback, res);
                     } else {
-                        callback(data[0].results);
+                        const genes = res.results.map((obj) => ({
+                            ...obj,
+                            name: obj.gene,
+                        }));
+                        callback(genes);
                     }
                 })
                 .catch((error) => {
@@ -299,8 +271,9 @@ export function initGeneSelect(
                 });
         },
     });
-    if (gene.gene)
-        setDefaultGene(select, gene.gene, gene.description, gene.domains);
+
+    if (gene.name)
+        setDefaultGene(select, gene.name, gene.description, gene.domains);
     if (multiple) initGeneSelectValues(select, selected);
     return select;
 }

--- a/app/templates/app/components/javascript_urls.html
+++ b/app/templates/app/components/javascript_urls.html
@@ -34,6 +34,8 @@ Prepare URLs to be used in JavaScript scripts
         "rest:stats-detail": "{% url 'rest:stats-detail' 'DATASET_PLACEHOLDER' %}",
 
         "rest:gene-list": "{% url 'rest:gene-list' %}",
+        "rest:genesearch-list": "{% url 'rest:genesearch-list' %}",
+
         "rest:domain-list": "{% url 'rest:domain-list' %}",
         "rest:genelist-list": "{% url 'rest:genelist-list' %}",
         "rest:ortholog-list": "{% url 'rest:ortholog-list' %}",

--- a/app/templates/app/components/modals/list_editor.html
+++ b/app/templates/app/components/modals/list_editor.html
@@ -258,7 +258,7 @@ Input:
                                                         </button>
                                                     </div>
 
-                                                    {% include "../select/gene.html" with id="append" name="gene_lists" hash=id limit=10 multiple="true" selected=query.gene_lists class=" " placeholder="Search genes, gene lists and domains..." %}
+                                                    {% include "../select/gene.html" with id="append" name="gene_lists" hash=id limit=10 multiple="true" selected=query.gene_lists class=" " %}
                                                 </div>
 
                                                 <div class="col-auto">

--- a/app/templates/app/components/plots/expression_heatmap.html
+++ b/app/templates/app/components/plots/expression_heatmap.html
@@ -84,7 +84,7 @@ Input:
                     </div>
                 </div>
 
-                {% include "../select/gene.html" with id=id name="gene_lists" hash=id limit=10 multiple="true" selected=query.gene_lists class=" " placeholder="Search genes, gene lists and domains..." width="400px" %}
+                {% include "../select/gene.html" with id=id name="gene_lists" hash=id limit=10 multiple="true" selected=query.gene_lists class=" " width="400px" %}
             {% endif %}
         </div>
 

--- a/app/templates/app/components/select/dataset.html
+++ b/app/templates/app/components/select/dataset.html
@@ -24,9 +24,10 @@ Input:
 
 {% endcomment %}
 
+<!-- Make select invisible and add margin-bottom to avoid Flash Of Unstyled Content (FOUC) -->
 <style>
     #dataset-select-{{ id }} {
-        margin-bottom: 15px !important;
+        margin-bottom: 18px !important;
         visibility: hidden;
         max-width: 200px;
         {% if width %} width: {{ width }} !important; {% endif %}
@@ -37,7 +38,6 @@ Input:
     }
 </style>
 
-<!-- Make select invisible and with margin of 15px to avoid Flash Of Unstyled Content (FOUC) -->
 <select id="dataset-select-{{ id }}"
         class="mb-2 {{ class }} {% if small == 'true' %}small{% endif %}"
         placeholder="{{ placeholder|default:'Search datasets by species, taxonomic rank, division, ...' }}">

--- a/app/templates/app/components/select/gene.html
+++ b/app/templates/app/components/select/gene.html
@@ -25,15 +25,18 @@ Input:
   URL using a query parameter (e.g., '?gene=BRCA1'); if 'arg', redirect using
   gene as an argument
 - hash: hash to add to URL (default: none)
-- limit: maximum number of genes to fetch from API (default: 50)
+- limit: maximum number of genes to fetch from API (default: 50 genes or 3 if multiple)
 
 {% endcomment %}
 
+<!-- Make select invisible and add margin to avoid Flash Of Unstyled Content (FOUC) -->
 <select id="{{ id }}_gene_selection"
         class="{{ class|default:'mb-3' }}"
         name="{{ name|default:'gene' }}"
-        style="width: {{ width|default:'100%' }}"
-        placeholder="{{ placeholder|default:'Search gene...' }}"
+        style="width: {{ width|default:'100%' }};
+               visibility: hidden;
+               margin-top: 12px"
+        placeholder="{% if placeholder %}{{ placeholder }}{% elif multiple == 'true' %}Search gene lists, modules, domains...{% else %}Search gene...{% endif %}"
         {% if multiple == 'true' %}multiple{% endif %}
         {% if disabled == 'true' %}disabled{% endif %}>
     <option value="">
@@ -64,7 +67,7 @@ Input:
             ]
         },
         selected = "{{ selected }}",
-        limit = {{limit|default:50}},
+        limit = {% if limit %}{{ limit }}{% elif multiple == "true" %}3{% else %}50{% endif %},
         multiple = "{{ multiple }}",
         display = "{{ display|default:'name' }}" === "all";
 

--- a/app/templates/app/components/select/metacell.html
+++ b/app/templates/app/components/select/metacell.html
@@ -17,8 +17,11 @@ Input:
 
 {% endcomment %}
 
+<!-- Make select invisible and add margin to avoid Flash Of Unstyled Content (FOUC) -->
 <select required
         name="{{ name|default:'metacells' }}"
+        style="visibility: hidden;
+               margin: 10px"
         value=""
         id="metacells"
         multiple

--- a/config/pre_settings.py
+++ b/config/pre_settings.py
@@ -25,6 +25,13 @@ def get_diamond_version():
     return version
 
 
+def get_goatools_version():
+    """Get version of GOATOOLS installed."""
+    output = get_command_output(["goatools", "--version"])
+    version = re.search(r"[\w\.]+", output.split()[-1]).group()
+    return version
+
+
 def get_latest_git_tag():
     """Get latest GitHub tag of this project."""
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -17,7 +17,7 @@ import sys
 
 import orjson
 
-from .pre_settings import get_diamond_version, get_env, get_latest_git_tag
+from .pre_settings import get_diamond_version, get_goatools_version, get_env, get_latest_git_tag
 from rest.settings import sort_api_tags
 
 # GLOBAL VARIABLES: registered in context_processors.py
@@ -33,6 +33,7 @@ GITHUB_URL = "https://github.com/biodiversitycellatlas/bca-website"
 GIT_VERSION = get_latest_git_tag()
 
 DIAMOND_VERSION = get_diamond_version()
+GOATOOLS_VERSION = get_goatools_version()
 
 # Max sequences for alignment
 MAX_ALIGNMENT_SEQS = get_env("BCA_APP_MAX_ALIGNMENT_SEQS", 100, type="int")

--- a/docker-entrypoint-initdb.d/postgres_init.sql
+++ b/docker-entrypoint-initdb.d/postgres_init.sql
@@ -4,8 +4,5 @@
 ALTER SYSTEM SET max_wal_size = '2GB'; -- noqa
 SELECT pg_reload_conf();
 
--- Activate trigram similarity search
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
-
 -- Create databases if needed
 CREATE DATABASE ghost;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ py-modules = []
 [tool.pytest]
 DJANGO_SETTINGS_MODULE="config.settings"
 testpaths = ["app/tests", "rest/tests"]
-python_files = ["test_*.py"]
+python_files = ["test_*.py", "tests.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = ["--tb=short", "--ignore=scripts", "-s"]

--- a/rest/filters.py
+++ b/rest/filters.py
@@ -313,7 +313,10 @@ class GeneListFilter(QueryFilterSet):
     species = SpeciesChoiceFilter(field_name="genes")
     q = CharFilter(
         method="query",
-        label="Query string to filter results. The string will be searched and ranked across gene list names and description.",
+        label=(
+            "Query string to filter results. "
+            "The string will be searched and ranked across gene list names and description."
+        ),
     )
     query_fields = ["name", "description"]
 

--- a/rest/filters.py
+++ b/rest/filters.py
@@ -279,7 +279,7 @@ class DomainFilter(QueryFilterSet):
     species = SpeciesChoiceFilter(field_name="gene")
     q = CharFilter(
         method="query",
-        label=("Query string to filter results. The string will be searched and ranked across domain names."),
+        label="Query string to filter results. The string will be searched and ranked across domain names.",
     )
     query_fields = ["name"]
     order_by_gene_count = BooleanFilter(method=skip_param, label="Order results by gene count (ascending).")
@@ -307,10 +307,15 @@ class DomainFilter(QueryFilterSet):
         return queryset
 
 
-class GeneListFilter(FilterSet):
+class GeneListFilter(QueryFilterSet):
     """Filter set for gene lists."""
 
     species = SpeciesChoiceFilter(field_name="genes")
+    q = CharFilter(
+        method="query",
+        label="Query string to filter results. The string will be searched and ranked across gene list names.",
+    )
+    query_fields = ["name"]
 
     class Meta:
         """Configuration for model and filterable fields."""
@@ -324,11 +329,17 @@ class GeneListFilter(FilterSet):
         return queryset.distinct()
 
 
-class GeneModuleFilter(FilterSet):
+class GeneModuleFilter(QueryFilterSet):
     """Filter set for gene modules."""
 
     dataset = DatasetChoiceFilter()
     order_by_gene_count = BooleanFilter(method=skip_param, label="Order results by gene count (descending).")
+
+    q = CharFilter(
+        method="query",
+        label="Query string to filter results. The string will be searched and ranked across gene module names.",
+    )
+    query_fields = ["name"]
 
     class Meta:
         """Configuration for model and filterable fields."""
@@ -604,19 +615,20 @@ class MetacellGeneExpressionFilter(FilterSet):
     dataset = DatasetChoiceFilter(required=True)
     genes = CharFilter(
         label=(
-            "Comma-separated list of <a href='#/operations/genes_list'>genes</a>, "
-            "<a href='#/operations/gene_lists_list'>gene lists</a> and "
-            "<a href='#/operations/domains_list'>domains</a> to retrieve data for. "
+            "Comma-separated list of [genes](#/operations/genes_list), "
+            "[gene lists](#/operations/gene_lists_list), "
+            "[gene modules](#/operations/modules_list), "
+            "[domains](#/operations/domains_list) to retrieve data for. "
             "If not provided, data is returned for all genes."
         ),
         method="filter_genes",
     )
     metacells = CharFilter(
-        label=("Comma-separated list of <a href='#/operations/metacells_list'>metacell names and cell types</a>."),
+        label="Comma-separated list of [metacell names and cell types](#/operations/metacells_list).",
         method="filter_metacells",
     )
     fc_min = NumberFilter(
-        label="Filter expression data by minimum fold-change (default: <kbd>0</kbd>).",
+        label="Filter expression data by minimum fold-change (default: `0`).",
         field_name="fold_change",
         lookup_expr="gte",
     )
@@ -627,28 +639,31 @@ class MetacellGeneExpressionFilter(FilterSet):
     sort_genes = SortAcrossMetacellFilter(
         field_name="gene",
         order_field="fold_change",
-        label=("Sort genes based on their highest expression value across metacells (default: <kbd>false</kbd>)."),
+        label="Sort genes based on their highest expression value across metacells (default: `false`).",
     )
     log2 = BooleanFilter(
-        label="Log2-transform <kbd>fold_change</kbd> (default: <kbd>false</kbd>).",
+        label="Log2-transform `fold_change` (default: `false`).",
         method="log2_transform",
     )
     clip_log2 = NumberFilter(
         label=(
-            "Set the maximum limit for <kbd>log2_fold_change</kbd> values "
-            "(requires <kbd>log2=true</kbd>). If <kbd>fc_min</kbd> is higher, "
-            "<kbd>clip_log2</kbd> is set to <kbd>fc_min</kbd>."
+            "Set the maximum limit for `log2_fold_change` values (requires `log2=true`). "
+            "If `fc_min` is higher, `clip_log2` is set to `fc_min`."
         ),
         method="clip_expression",
     )
 
     def filter_genes(self, queryset, name, value):
-        """Filter queryset by gene names, domains or gene lists."""
+        """Filter queryset by gene names, domains, gene lists and gene modules."""
 
         if value:
             genes = value.split(",")
+
             queryset = queryset.filter(
-                Q(gene__name__in=genes) | Q(gene__domains__name__in=genes) | Q(gene__genelists__name__in=genes)
+                Q(gene__name__in=genes)
+                | Q(gene__domains__name__in=genes)
+                | Q(gene__genelists__name__in=genes)
+                | Q(gene__modules__module__name__in=genes)
             ).distinct()
         return queryset
 
@@ -718,7 +733,7 @@ class CorrelatedGenesFilter(QueryFilterSet):
 
     dataset = DatasetChoiceFilter(required=True)
     gene = CharFilter(
-        label=("<a href='#/operations/genes_list'>Gene symbol</a> to retrieve top correlated genes for."),
+        label="[Gene symbol](#/operations/genes_list) to retrieve top correlated genes for.",
         method="filter_gene",
         required=True,
     )

--- a/rest/filters.py
+++ b/rest/filters.py
@@ -313,9 +313,9 @@ class GeneListFilter(QueryFilterSet):
     species = SpeciesChoiceFilter(field_name="genes")
     q = CharFilter(
         method="query",
-        label="Query string to filter results. The string will be searched and ranked across gene list names.",
+        label="Query string to filter results. The string will be searched and ranked across gene list names and description.",
     )
-    query_fields = ["name"]
+    query_fields = ["name", "description"]
 
     class Meta:
         """Configuration for model and filterable fields."""

--- a/rest/routers.py
+++ b/rest/routers.py
@@ -8,6 +8,7 @@ router.register("datasets", views.DatasetViewSet)
 router.register("stats", views.StatsViewSet, basename="stats")
 
 router.register("genes", views.GeneViewSet)
+router.register("gene_search", views.GeneSearchViewSet, basename="genesearch")
 
 router.register("gene_lists", views.GeneListViewSet)
 router.register("domains", views.DomainViewSet)

--- a/rest/serializers.py
+++ b/rest/serializers.py
@@ -287,6 +287,26 @@ class GeneNoSpeciesSerializer(GeneSerializer):
         fields = [f for f in GeneSerializer.Meta.fields if f != "species"]
 
 
+class GeneRequestSerializer(serializers.ModelSerializer):
+    """Gene request serializer."""
+
+    genes = serializers.ListField(
+        child=serializers.CharField(),
+        help_text=(
+            "Comma-separated list of [genes](#/operations/genes_list), "
+            "[gene lists](#/operations/gene_lists_list), "
+            "[domains](#/operations/domains_list) to retrieve data for. "
+            "If not provided, data is returned for all genes."
+        ),
+    )
+
+    class Meta:
+        """Meta configuration."""
+
+        model = models.Gene
+        fields = ["genes"]
+
+
 class DomainSerializer(serializers.ModelSerializer):
     """Protein domain serializer."""
 
@@ -307,10 +327,15 @@ class GeneListSerializer(serializers.ModelSerializer):
     def get_gene_count(self, obj) -> int:
         """Return number of genes in gene list."""
 
+        request = self.context.get("request")
+        species = self.context.get("species")
+        if species is None and request:
+            species = request.query_params.get("species")
+
         genes = obj.genes
-        species = self.context.get("request").query_params.get("species", None)
         if species:
             genes = genes.filter(species__scientific_name=species)
+
         return genes.count()
 
     class Meta:
@@ -793,6 +818,15 @@ class SAMapSerializer(serializers.ModelSerializer):
         return self._get_metacell_types(obj)[1].color
 
 
+class GeneSearchSerializer(serializers.Serializer):
+    """Serializer for gene search."""
+
+    gene_lists = GeneListSerializer(many=True)
+    gene_modules = GeneModuleSerializer(many=True)
+    domains = DomainSerializer(many=True)
+    genes = GeneSerializer(many=True)
+
+
 @extend_schema_serializer(
     examples=[
         OpenApiExample(
@@ -874,45 +908,17 @@ class EnrichmentAnalysisRequestSerializer(serializers.Serializer):
         default=False,
         help_text="If true, obsolete terms will be included in the analysis.",
     )
-
-    # Available gene input options
     genes = serializers.ListField(
         child=serializers.CharField(),
-        required=False,
+        required=True,
         help_text=(
-            "Array of genes to use as query genes. "
-            "These genes are combined with genes from `gene_modules` and `gene_lists`."
+            "Comma-separated list of [genes](#/operations/genes_list), "
+            "[gene lists](#/operations/gene_lists_list), "
+            "[gene modules](#/operations/modules_list), "
+            "[domains](#/operations/domains_list) to retrieve data for. "
+            "If not provided, data is returned for all genes."
         ),
     )
-    gene_modules = serializers.ListField(
-        child=serializers.CharField(),
-        required=False,
-        help_text=(
-            "Array of [gene modules](#/operations/modules_list) to use as query genes. "
-            "Genes from the selected modules are combined with genes from `genes` and `gene_lists`."
-        ),
-    )
-    gene_lists = serializers.ListField(
-        child=serializers.CharField(),
-        required=False,
-        help_text=(
-            "Array of [preset gene lists](#/operations/gene_lists_list) to use as query genes. "
-            "Genes from the selected lists are combined with genes from `genes` and `gene_modules`."
-        ),
-    )
-
-    def validate(self, attrs):
-        # Validate if defining at least one of: genes, gene_modules or gene_lists
-        genes = attrs.get("genes")
-        gene_modules = attrs.get("gene_modules")
-        gene_lists = attrs.get("gene_lists")
-
-        if not any([genes, gene_modules, gene_lists]):
-            raise serializers.ValidationError(
-                "At least one of 'genes', 'gene_modules', or 'gene_lists' must be provided."
-            )
-
-        return attrs
 
 
 class EnrichmentAnalysisResponseSerializer(serializers.Serializer):
@@ -923,12 +929,7 @@ class EnrichmentAnalysisResponseSerializer(serializers.Serializer):
     )
     term = serializers.CharField(help_text="Term ID.", source="GO")
     name = serializers.CharField(help_text="Term name.")
-    enrichment = serializers.CharField(
-        help_text=(
-            "Term enrichment: enriched (significantly higher compared to background genes) "
-            "or purified (significantly lower)."
-        )
-    )
+    fold_enrichment = serializers.FloatField(help_text="Fold enrichment: >1 indicates enrichment, <1 depletion.")
 
     depth = serializers.IntegerField(
         help_text="Hierarchy depth: higher for more specific terms.", source="goterm.depth"
@@ -946,14 +947,16 @@ class EnrichmentAnalysisResponseSerializer(serializers.Serializer):
     qvalue = serializers.FloatField(help_text="Statistical significance (Bonferroni).", source="get_pvalue")
 
     query_hit_count = serializers.SerializerMethodField(help_text="Number of input genes associated with the term.")
-    query_count = serializers.SerializerMethodField(help_text="Number of input genes.")
+    query_count = serializers.SerializerMethodField(help_text="Total number of input genes.")
     background_hit_count = serializers.SerializerMethodField(
         help_text="Number of background genes associated with the term."
     )
-    background_count = serializers.SerializerMethodField(help_text="Number of background genes.")
+    background_count = serializers.SerializerMethodField(help_text="Total number of background genes.")
 
     genes = serializers.ListField(
-        child=serializers.CharField(), help_text="Input genes associated with the term.", source="study_items"
+        child=serializers.CharField(),
+        help_text="Name of input genes associated with the term.",
+        source="study_items",
     )
 
     similarity_coords = serializers.ListField(

--- a/rest/tests/test_enrichment.py
+++ b/rest/tests/test_enrichment.py
@@ -11,7 +11,6 @@ from goatools.obo_parser import GODag
 
 from app.models import (
     Species,
-    Dataset,
     GlobalFile,
     GeneList,
 )

--- a/rest/tests/test_enrichment.py
+++ b/rest/tests/test_enrichment.py
@@ -11,6 +11,7 @@ from goatools.obo_parser import GODag
 
 from app.models import (
     Species,
+    Dataset,
     GlobalFile,
     GeneList,
 )
@@ -69,13 +70,13 @@ class EnrichmentAnalysisTests(APITestCase):
                 cls.aque_adult.mge.create(gene=g, metacell=mc1)
                 cls.genes.append(gene)
 
-    def check_enrichment_response(self, response, genes, obsolete=False):
+    def check_enrichment_response(self, response, dataset, genes, obsolete=False):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual(response.data, [], "Expect non-empty results")
 
         for d in response.data:
             self.assertRegex(d["term"], r"^GO:\d{7}$", "Expected GO term name")
-            self.assertIn(d["enrichment"], {"e", "p"}, "Enrichment results")
+            self.assertIsInstance(d["fold_enrichment"], (int, float), "Enrichment results")
 
             if obsolete:
                 self.assertGreaterEqual(d["depth"], 0, "GO term depth ≥ 0")
@@ -90,14 +91,16 @@ class EnrichmentAnalysisTests(APITestCase):
                 for d in response.data:
                     self.assertEqual(go_obo[d["term"]].is_obsolete, d.get("is_obsolete"))
             else:
-                self.assertGreaterEqual(d["depth"], 1, "GO term depth ≥ 1")
+                self.assertGreaterEqual(d["depth"], 0, "GO term depth ≥ 0")
                 self.assertNotIn("is_obsolete", d, "No obsolete field")
 
-            self.assertSetEqual(set(d["genes"]), genes, "Genes match input in these examples")
-            self.assertEqual(d["query_count"], len(d["genes"]), "Match number of genes")
-            self.assertEqual(d["query_hit_count"], len(d["genes"]), "Match number of genes")
-            self.assertEqual(d["background_hit_count"], len(d["genes"]), "Match number of genes")
-            self.assertEqual(d["background_count"], len(self.genes), "Match all genes")
+            background = dataset.mge.count()
+
+            self.assertTrue(set(d["genes"]).issubset(set(genes)), "Genes match input in these examples")
+            self.assertLessEqual(d["query_count"], len(genes), "Match number of genes")
+            self.assertLessEqual(d["query_hit_count"], len(genes), "Match number of genes")
+            self.assertLessEqual(d["background_hit_count"], background, "Match number of genes")
+            self.assertEqual(d["background_count"], background, "Match all genes")
 
             self.assertTrue(0 <= d["pvalue"] <= 1, "Expected p-value")
             self.assertTrue(0 <= d["qvalue"] <= 1, "Expected adjusted p-value")
@@ -113,10 +116,11 @@ class EnrichmentAnalysisTests(APITestCase):
 
     def test_post(self):
         url = "/api/v1/enrichment/"
+        dataset = self.aque_adult
         genes = {"Aque_Aqu2.1.30266_001", "Aque_Aqu2.1.30264_001", "Aque_Aqu2.1.30269_001"}
-        data = dict(dataset="amphimedon-queenslandica-adult", genes=genes)
+        data = dict(dataset=dataset.slug, genes=genes)
         response = self.client.post(url, data, format="json")
-        self.check_enrichment_response(response, genes)
+        self.check_enrichment_response(response, dataset, genes)
         self.assertSetEqual({d["term"] for d in response.data} - self.go_terms, set(), "Expected GO terms")
 
         # Test with valid and invalid genes: silently ignores invalid genes
@@ -124,77 +128,83 @@ class EnrichmentAnalysisTests(APITestCase):
         valid_genes = {"Aque_Aqu2.1.30266_001", "Aque_Aqu2.1.30264_001", "Aque_Aqu2.1.30269_001"}
         genes = invalid_genes | valid_genes
 
-        data = dict(dataset="amphimedon-queenslandica-adult", genes=genes)
+        data = dict(dataset=dataset.slug, genes=genes)
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.check_enrichment_response(response, valid_genes)
+        self.check_enrichment_response(response, dataset, valid_genes)
 
     def test_post_obsolete(self):
         """Test if obsolete terms are included."""
         url = "/api/v1/enrichment/"
+        dataset = self.aque_adult
         genes = {"Aque_Aqu2.1.30266_001", "Aque_Aqu2.1.30264_001", "Aque_Aqu2.1.30269_001"}
-        data = dict(dataset="amphimedon-queenslandica-adult", genes=genes, obsolete=True)
+        data = dict(dataset=dataset.slug, genes=genes, obsolete=True)
         response = self.client.post(url, data, format="json")
-        self.check_enrichment_response(response, genes, obsolete=True)
+        self.check_enrichment_response(response, dataset, genes, obsolete=True)
         self.assertSetEqual({d["term"] for d in response.data} - self.go_terms, set(), "Expected GO terms")
 
     def test_post_no_enrichment(self):
         """Test no enrichment results."""
 
         url = "/api/v1/enrichment/"
+        dataset = self.aque_adult
         genes = {"Aque_Aqu2.1.30266_001", "Aque_Aqu2.1.30264_001"}
-        data = dict(dataset="amphimedon-queenslandica-adult", genes=genes)
+        data = dict(dataset=dataset.slug, genes=genes)
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, [])
 
     def test_post_gene_queries(self):
         """Test multiple types of gene queries."""
+
         url = "/api/v1/enrichment/"
-        all_genes = ["Aque_Aqu2.1.30266_001", "Aque_Aqu2.1.30269_001", "Aque_Aqu2.1.30264_001"]
-        genes = all_genes[0]
+        dataset = self.aque_adult
+        all_genes = [
+            "Aque_Aqu2.1.04552_001",
+            "Aque_Aqu2.1.05595_001",
+            "Aque_Aqu2.1.06672_001",
+            "Aque_Aqu2.1.06863_001",
+            "Aque_Aqu2.1.07919_001",
+            "Aque_Aqu2.1.13978_001",
+            "Aque_Aqu2.1.26492_001",
+            "Aque_Aqu2.1.30238_001",
+            "Aque_Aqu2.1.30239_001",
+            "Aque_Aqu2.1.30240_001",
+            "Aque_Aqu2.1.30264_001",
+            "Aque_Aqu2.1.30266_001",
+            "Aque_Aqu2.1.30269_001",
+        ]
+        genes = all_genes[0:3]
+        genelist_genes = all_genes[3:8]
+        module_genes = all_genes[8:13]
 
         genelist_name = "random list"
         genelist = GeneList.objects.create(name=genelist_name)
-        for gene in self.aque_adult.species.genes.filter(name=all_genes[1]):
+        for gene in dataset.species.genes.filter(name__in=genelist_genes):
             genelist.genes.add(gene)
 
         module_name = "GM23"
         module = self.aque_adult.gene_modules.create(name=module_name)
-        for gene in self.aque_adult.species.genes.filter(name=all_genes[2]):
+        for gene in dataset.species.genes.filter(name__in=module_genes):
             module.genes.add(gene)
 
-        data = dict(
-            dataset="amphimedon-queenslandica-adult",
-            genes=[genes],
-            gene_lists=[genelist_name],
-            gene_modules=[module_name],
-        )
+        # Fetch by all options
+        data = dict(dataset=dataset.slug, genes=[*genes, genelist_name, module_name])
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.check_enrichment_response(response, set(all_genes))
+        self.check_enrichment_response(response, dataset, set(all_genes))
 
-        # Invalid gene module name
-        data = dict(
-            dataset="amphimedon-queenslandica-adult",
-            genes=[genes],
-            gene_lists=[genelist_name],
-            gene_modules=["wrong name"],
-        )
+        # Fetch by gene module name alone
+        data = dict(dataset=dataset.slug, genes=[module_name])
         response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn("not found", response.data["detail"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.check_enrichment_response(response, dataset, set(all_genes))
 
-        # Invalid gene list name
-        data = dict(
-            dataset="amphimedon-queenslandica-adult",
-            genes=[genes],
-            gene_lists=["rbp"],
-            gene_modules=[module_name],
-        )
+        # Fetch by gene list name
+        data = dict(dataset=dataset.slug, genes=[genelist_name])
         response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn("not found", response.data["detail"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.check_enrichment_response(response, dataset, set(all_genes))
 
     def test_post_invalid(self):
         """Test invalid input."""
@@ -216,24 +226,20 @@ class EnrichmentAnalysisTests(APITestCase):
         self.assertIn("Cannot find dataset for random-dataset", str(ctx.exception))
 
         # No genes in request
-        data = dict(dataset="amphimedon-queenslandica-adult")
+        dataset = self.aque_adult
+        data = dict(dataset=dataset.slug)
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("non_field_errors", response.data)
-        self.assertIn(
-            "At least one of 'genes', 'gene_modules', or 'gene_lists' must be provided.",
-            response.data["non_field_errors"],
-        )
 
         # Empty gene array
-        data = dict(dataset="amphimedon-queenslandica-adult", genes=[])
+        data = dict(dataset=dataset.slug, genes=[])
         response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("non_field_errors", response.data)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("Genes not found", response.data["detail"])
 
         # Non-existing genes
         genes = ["random", "arbitrary", "gene"]
-        data = dict(dataset="amphimedon-queenslandica-adult", genes=genes)
+        data = dict(dataset=dataset.slug, genes=genes)
         response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn("not found", response.data["detail"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [], "Expect empty results")

--- a/rest/tests/tests.py
+++ b/rest/tests/tests.py
@@ -99,16 +99,50 @@ class GeneTests(APITestCase):
 
     @classmethod
     def setUpTestData(cls):
-        species1 = Species.objects.create(common_name="rat", scientific_name="Rat", description="rat")
-        Gene.objects.create(species=species1, name="Gene1", description="description1")
-        Gene.objects.create(species=species1, name="Gene2", description="description2")
+        mouse = Species.objects.create(scientific_name="Mus musculus")
+        mouse.genes.create(name="Gene1")
+        mouse.genes.create(name="Gene2")
+        mouse.genes.create(name="Gene3")
 
-    def test_genes(self):
-        response = self.client.get("/api/v1/genes/", format="json")
+    def test_get(self):
+        url = "/api/v1/genes/"
+        response = self.client.get(url, format="json")
         genes = response.data["results"]
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(genes) == 3
+        assert {s["gene"] for s in genes} == {"Gene1", "Gene2", "Gene3"}
+
+    def test_get_filtered_by_genes(self):
+        subset = {"Gene1", "Gene3"}
+        url = "/api/v1/genes/?genes=" + ",".join(subset)
+        response = self.client.get(url, format="json")
+        genes = response.data["results"]
+
         assert response.status_code == status.HTTP_200_OK
         assert len(genes) == 2
-        assert {s["gene"] for s in genes} == {"Gene1", "Gene2"}
+        assert {s["gene"] for s in genes} == subset
+
+    def test_post(self):
+        url = "/api/v1/genes/"
+        payload = {}
+
+        response = self.client.post(url, payload, format="json")
+        genes = response.data["results"]
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(genes) == 0
+        assert genes == []
+
+    def test_get_filtered_by_genes(self):
+        url = "/api/v1/genes/"
+        payload = { "genes": {"Gene1", "Gene3"} }
+        response = self.client.post(url, payload, format="json")
+        genes = response.data["results"]
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(genes) == 2
+        assert {s["gene"] for s in genes} == payload["genes"]
 
 
 @override_settings(MEDIA_ROOT=tempfile.mkdtemp())

--- a/rest/tests/tests.py
+++ b/rest/tests/tests.py
@@ -145,6 +145,95 @@ class GeneTests(APITestCase):
         assert {s["gene"] for s in genes} == payload["genes"]
 
 
+class GeneSearchTests(APITestCase):
+    """Test GeneSearch Endpoint"""
+
+    @classmethod
+    def setUpTestData(cls):
+        mouse = Species.objects.create(scientific_name="Mus musculus")
+        cls.adult_mouse = mouse.datasets.create(name="adult")
+
+        # Create genes
+        mouse.genes.create(name="Trp53")
+        mouse.genes.create(name="Actb")
+        mouse.genes.create(name="Gapdh", description="Green-yellow submarine")
+        mouse.genes.create(name="Myc", description="Green-yellow submarine")
+        mouse.genes.create(name="Brca1")
+        mouse.genes.create(name="Brca2")
+        mouse.genes.create(name="Ptprc")
+        mouse.genes.create(name="Il6", description="Green-yellow submarine")
+        mouse.genes.create(name="Tnf")
+        mouse.genes.create(name="Sox2")
+        genes = mouse.genes.all()
+
+        # Create modules
+        module1 = cls.adult_mouse.gene_modules.create(name="blue")
+        module2 = cls.adult_mouse.gene_modules.create(name="green")
+        module3 = cls.adult_mouse.gene_modules.create(name="yellow")
+        module1.genes.add(*genes[0:4])
+        module2.genes.add(*genes[4:6])
+        module3.genes.add(*genes[6:10])
+
+        # Create gene lists
+        genelist1 = GeneList.objects.create(name="RBP", description="RNA-binding proteins")
+        genelist2 = GeneList.objects.create(name="TF", description="Transcription factors")
+        genelist3 = GeneList.objects.create(name="Custom list", description="List of Brca genes")
+        genelist1.genes.add(*genes[0:7])
+        genelist2.genes.add(*genes[5:10])
+        genelist3.genes.add(*mouse.genes.filter(name__startswith="Brca"))
+
+        # Create domains
+        domain1 = Domain.objects.create(name="Kinase")
+        domain2 = Domain.objects.create(name="Zinc finger")
+        domain1.gene_set.add(*genes[0:3])
+        domain2.gene_set.add(*genes[4:6])
+
+    def test_get(self):
+        """Test setting dataset only."""
+        dataset = self.adult_mouse.slug
+        limit = 3
+        url = f"/api/v1/gene_search/?dataset={dataset}&limit={limit}"
+        response = self.client.get(url, format="json")
+        data = response.data
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {s["gene"] for s in data["genes"]} == {"Actb", "Brca1", "Brca2"}
+        assert {s["name"] for s in data["gene_lists"]} == {"RBP", "TF", "Custom list"}
+        assert {s["module"] for s in data["gene_modules"]} == {"blue", "green", "yellow"}
+        assert {s["name"] for s in data["domains"]} == {"Kinase", "Zinc finger"}
+
+    def test_get_query(self):
+        """Test setting query string."""
+
+        # Test gene name (also matches the description of a list)
+        dataset = self.adult_mouse.slug
+        limit = 3
+        q = "brca"
+        url = f"/api/v1/gene_search/?dataset={dataset}&limit={limit}&q={q}"
+        response = self.client.get(url, format="json")
+        data = response.data
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {s["gene"] for s in data["genes"]} == {"Brca1", "Brca2"}
+        assert {s["name"] for s in data["gene_lists"]} == {"Custom list"}
+        assert data["gene_modules"] == []
+        assert data["domains"] == []
+
+        # Test module name (also matches description of a few genes)
+        dataset = self.adult_mouse.slug
+        limit = 3
+        q = "yellow"
+        url = f"/api/v1/gene_search/?dataset={dataset}&limit={limit}&q={q}"
+        response = self.client.get(url, format="json")
+        data = response.data
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {s["gene"] for s in data["genes"]} == {"Gapdh", "Myc", "Il6"}
+        assert data["gene_lists"] == []
+        assert {s["module"] for s in data["gene_modules"]} == {"yellow"}
+        assert data["domains"] == []
+
+
 @override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class SingleCellGeneExpressionTests(APITestCase):
     """Tests SingleCellGeneExpression Endpoint"""

--- a/rest/tests/tests.py
+++ b/rest/tests/tests.py
@@ -136,7 +136,7 @@ class GeneTests(APITestCase):
 
     def test_get_filtered_by_genes(self):
         url = "/api/v1/genes/"
-        payload = { "genes": {"Gene1", "Gene3"} }
+        payload = {"genes": {"Gene1", "Gene3"}}
         response = self.client.post(url, payload, format="json")
         genes = response.data["results"]
 

--- a/rest/tests/tests.py
+++ b/rest/tests/tests.py
@@ -134,9 +134,9 @@ class GeneTests(APITestCase):
         assert len(genes) == 0
         assert genes == []
 
-    def test_get_filtered_by_genes(self):
+    def test_post_filtered_by_genes(self):
         url = "/api/v1/genes/"
-        payload = { "genes": {"Gene1", "Gene3"} }
+        payload = { "genes": { "Gene1", "Gene3" } }
         response = self.client.post(url, payload, format="json")
         genes = response.data["results"]
 

--- a/rest/tests/tests.py
+++ b/rest/tests/tests.py
@@ -136,7 +136,7 @@ class GeneTests(APITestCase):
 
     def test_post_filtered_by_genes(self):
         url = "/api/v1/genes/"
-        payload = { "genes": { "Gene1", "Gene3" } }
+        payload = {"genes": {"Gene1", "Gene3"}}
         response = self.client.post(url, payload, format="json")
         genes = response.data["results"]
 

--- a/rest/views.py
+++ b/rest/views.py
@@ -795,16 +795,12 @@ class EnrichmentAnalysisViewSet(viewsets.ViewSet):
         if len(genes) == 0:
             raise NotFound(detail="Genes not found.")
 
-        queryset = (
-            dataset.species.genes
-            .filter(
-                Q(name__in=genes)
-                | Q(domains__name__in=genes)
-                | Q(genelists__name__in=genes)
-                | Q(modules__module__name__in=genes, modules__module__dataset=dataset)
-            )
-            .distinct()
-        )
+        queryset = dataset.species.genes.filter(
+            Q(name__in=genes)
+            | Q(domains__name__in=genes)
+            | Q(genelists__name__in=genes)
+            | Q(modules__module__name__in=genes, modules__module__dataset=dataset)
+        ).distinct()
 
         # Get name of selected genes
         query = list(queryset.values_list("name", flat=True))

--- a/rest/views.py
+++ b/rest/views.py
@@ -796,12 +796,12 @@ class EnrichmentAnalysisViewSet(viewsets.ViewSet):
             raise NotFound(detail="Genes not found.")
 
         queryset = (
-            dataset.species.genes.filter(modules__module__dataset=dataset)
+            dataset.species.genes
             .filter(
                 Q(name__in=genes)
                 | Q(domains__name__in=genes)
                 | Q(genelists__name__in=genes)
-                | Q(modules__module__name__in=genes)
+                | Q(modules__module__name__in=genes, modules__module__dataset=dataset)
             )
             .distinct()
         )

--- a/rest/views.py
+++ b/rest/views.py
@@ -7,7 +7,7 @@ import tempfile
 from urllib.parse import unquote_plus
 
 from django.conf import settings
-from django.db.models import Case, Count, IntegerField, Prefetch, Value, When
+from django.db.models import Case, Count, IntegerField, Prefetch, Value, When, Q
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema
 from rest_framework import viewsets, status
 from rest_framework.exceptions import NotFound
@@ -144,7 +144,18 @@ class GeneListViewSet(BaseReadOnlyModelViewSet):
     lookup_field = "name"
 
 
-@extend_schema(summary="List modules", tags=["Gene module"])
+@extend_schema(
+    summary="List modules",
+    tags=["Gene module"],
+    parameters=[
+        OpenApiParameter(
+            "q",
+            str,
+            description=filters.GeneModuleFilter().base_filters["q"].label,
+            examples=[OpenApiExample("Example", value="GM5")],
+        ),
+    ],
+)
 class GeneModuleViewSet(BaseReadOnlyModelViewSet):
     """List gene modules."""
 
@@ -272,6 +283,27 @@ class GeneViewSet(BaseReadOnlyModelViewSet):
     serializer_class = serializers.GeneSerializer
     filterset_class = filters.GeneFilter
     lookup_field = "name"
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("q", exclude=True),
+            OpenApiParameter("genes", exclude=True),
+        ],
+        request=serializers.GeneRequestSerializer,
+        operation_id="genes_post",
+        responses={200: serializers.GeneSerializer(many=True)},
+    )
+    def create(self, request, *args, **kwargs):
+        """Inject POST request data into GET parameters and call GET method."""
+
+        genes = request.data.get("genes")
+        genes = ",".join(genes) if genes and genes != [""] else [""]
+
+        query_params = request.query_params.copy()
+        query_params.update({**request.data, "genes": genes})
+
+        request._request.GET = query_params
+        return self.list(request, *args, **kwargs)
 
 
 @extend_schema(summary="List orthologs", tags=["Gene", "Cross-species"])
@@ -545,6 +577,69 @@ class MetacellCountViewSet(BaseReadOnlyModelViewSet):
     filterset_class = filters.MetacellCountFilter
 
 
+@extend_schema(summary="Search gene-associated data", tags=["Gene", "Gene module"])
+class GeneSearchViewSet(BaseReadOnlyModelViewSet):
+    """Search query across gene annotation, preset lists, modules and domains."""
+
+    queryset = models.Gene.objects.none()
+    serializer_class = serializers.GeneSearchSerializer
+    pagination_class = None
+
+    SEARCHES = {
+        "gene_lists": (filters.GeneListFilter, models.GeneList.objects.all(), serializers.GeneListSerializer),
+        "gene_modules": (filters.GeneModuleFilter, models.GeneModule.objects.all(), serializers.GeneModuleSerializer),
+        "domains": (filters.DomainFilter, models.Domain.objects.all(), serializers.DomainSerializer),
+        "genes": (filters.GeneFilter, models.Gene.objects.all(), serializers.GeneSerializer),
+    }
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "dataset",
+                str,
+                required=True,
+                description="The [dataset's slug](#/operations/datasets_list).",
+                examples=[OpenApiExample("Dataset", value="amphimedon-queenslandica-adult")],
+            ),
+            OpenApiParameter(
+                "q",
+                str,
+                description="Query string to search.",
+                examples=[OpenApiExample("Query", value="ATP")],
+            ),
+            OpenApiParameter(
+                "limit",
+                int,
+                description="Number of results to return per category (`3` by default).",
+            ),
+        ],
+    )
+    def list(self, request):
+        q = request.query_params.get("q")
+        dataset = request.query_params.get("dataset")
+        limit = int(request.query_params.get("limit", 3))
+
+        species = parse_species_dataset(dataset).species.scientific_name
+        params = {
+            "q": q,
+            "species": species,
+            "dataset": dataset,
+            "order_by_gene_count": True,
+        }
+
+        resp = Response(
+            {
+                key: serializer(
+                    filterset(data=params, queryset=queryset).qs[:limit],
+                    many=True,
+                    context={"species": species},
+                ).data
+                for key, (filterset, queryset, serializer) in self.SEARCHES.items()
+            }
+        )
+        return resp
+
+
 @extend_schema(
     summary="Align sequences",
     description="Align query sequences against the protein sequences in the BCA database "
@@ -677,59 +772,42 @@ class AlignViewSet(viewsets.ViewSet):
 @extend_schema(
     summary="Analyze GO enrichment",
     tags=["Gene ontology"],
+    description=f"""
+Perform **Gene Ontology (GO) enrichment analysis** on a set of genes
+using [GOATOOLS {settings.GOATOOLS_VERSION}](https://github.com/tanghaibao/goatools).
+
+Background genes are derived from all the genes in the selected dataset's metacell gene expression.
+
+> Processing may take 10+ seconds depending on input.
+> Please use responsibly to avoid excessive server load.
+""",
 )
 class EnrichmentAnalysisViewSet(viewsets.ViewSet):
-    """
-    Perform **Gene Ontology (GO) enrichment analysis** on a set of genes.
-
-    Background genes are derived from all the genes in the selected dataset's metacell gene expression.
-
-    > Processing may take 10+ seconds depending on input.
-    > Please use responsibly to avoid excessive server load.
-    """
+    """Perform enrichment analysis."""
 
     queryset = models.Gene.objects.all()
     serializer_class = serializers.EnrichmentAnalysisResponseSerializer
     pagination_class = None
 
-    def _get_gene_names(self, qs):
-        model = qs.model
+    def _prepare_gene_query(self, dataset, genes):
+        """Create array of gene names from genes, modules, lists and domains."""
 
-        if qs.model == models.Gene:
-            value = "name"
-        elif hasattr(model, "genes"):
-            value = "genes__name"
-        elif hasattr(model, "gene"):
-            value = "gene__name"
-        return list(qs.values_list(value, flat=True).distinct())
+        if len(genes) == 0:
+            raise NotFound(detail="Genes not found.")
 
-    def _prepare_gene_query(self, dataset, validated):
-        """Create array of gene names from genes, gene_modules and gene_lists."""
-        query = []
-
-        gene_names = validated.get("genes")
-        if gene_names:
-            genes = self._get_gene_names(dataset.species.genes.filter(name__in=gene_names))
-            if len(genes) == 0:
-                raise NotFound(detail=f"Genes {gene_names} not found.")
-            query += genes
-
-        gene_modules = validated.get("gene_modules")
-        if gene_modules:
-            genes = self._get_gene_names(dataset.gene_modules.filter(name__in=gene_modules))
-            if len(genes) == 0:
-                raise NotFound(detail=f"Gene modules {gene_modules} not found.")
-            query += genes
-
-        gene_lists = validated.get("gene_lists")
-        if gene_lists:
-            genes = self._get_gene_names(
-                models.GeneList.objects.filter(genes__species=dataset.species, name__in=gene_lists)
+        queryset = (
+            dataset.species.genes.filter(modules__module__dataset=dataset)
+            .filter(
+                Q(name__in=genes)
+                | Q(domains__name__in=genes)
+                | Q(genelists__name__in=genes)
+                | Q(modules__module__name__in=genes)
             )
-            if len(genes) == 0:
-                raise NotFound(detail=f"Gene lists {gene_lists} not found.")
-            query += genes
+            .distinct()
+        )
 
+        # Get name of selected genes
+        query = list(queryset.values_list("name", flat=True))
         return query
 
     @extend_schema(
@@ -743,11 +821,12 @@ class EnrichmentAnalysisViewSet(viewsets.ViewSet):
         validated = input_serializer.validated_data
 
         # Parse query parameters
-        dataset = parse_species_dataset(validated["dataset"])
-        genes = self._prepare_gene_query(dataset, validated)
+        dataset = parse_species_dataset(validated.get("dataset"))
+        genes = self._prepare_gene_query(dataset, validated.get("genes"))
 
         qvalue = validated.get("qvalue", 0.05)
-        background = self._get_gene_names(dataset.mge)
+        background = list(dataset.mge.values_list("gene__name", flat=True).distinct())
+
         obsolete = validated["obsolete"] or False
 
         go_obo = models.GlobalFile.objects.get(type="go-basic-obo").file.path


### PR DESCRIPTION
Endpoint changes associated with GO enrichment analysis (#424 and #425)

## Changes

- **Improve gene selection element** for heatmap expression, gene page, etc.
	- Create `gene_search` endpoint to search across gene lists, modules, domains and genes based on `q` parameter
	    - Internally, this uses 4 endpoints (one for each object type) and prepares the output as a dictionary of results of each endpoint
	    - Allows to query via `QueryFilterSet` in `GeneList` and `GeneModule`
    	- Metacell expression endpoint can now filter by gene module
- Add POST method for `gene_list` endpoint
    - Injects gene input from POST method as GET params
    - Avoid URL length limits when fetching information for >400 genes
- Improve `enrichment` endpoint
    - Simplify gene input to single `genes` parameter (similar to other endpoints)
    - Return `fold_enrichment` instead of `enrichment`
- Improve REST docs
- Add unit tests and fix unit test issues
    - [Fix creating trigram extension](https://github.com/biodiversitycellatlas/bca-website/pull/423/commits/9e53d411fe2e08ca89b36010bc392aa00ff00d16)
    - [Fix pytest not running rest/tests.py](https://github.com/biodiversitycellatlas/bca-website/pull/423/commits/524489f78dfa8ee8e77cbf2aa864dfe35de69fce)