### PR TITLE
Install djLint from project dependencies

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -88,6 +88,11 @@ jobs:
                   fetch-depth: 0
                   persist-credentials: false
 
+            - name: Setup Python
+              uses: actions/setup-python@v6.3.0
+              with:
+                  python-version: '3.13' 
+
             - name: Install project dependencies
               run: pip install .[dev]
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -88,8 +88,8 @@ jobs:
                   fetch-depth: 0
                   persist-credentials: false
 
-            - name: Install djlint
-              run: pip install djlint
+            - name: Install project dependencies
+              run: pip install .[dev]
 
             - name: Lint HTML files with djlint
               run: djlint . --reformat

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -91,7 +91,7 @@ jobs:
             - name: Setup Python
               uses: actions/setup-python@v6.3.0
               with:
-                  python-version: '3.13'
+                  python-version: "3.13"
 
             - name: Install project dependencies
               run: pip install .[dev]

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -91,7 +91,7 @@ jobs:
             - name: Setup Python
               uses: actions/setup-python@v6.3.0
               with:
-                  python-version: '3.13' 
+                  python-version: '3.13'
 
             - name: Install project dependencies
               run: pip install .[dev]


### PR DESCRIPTION
Pin version of djLint based on `pyproject.toml` to fix issue with old dependency of Click when installing the newest djLint version.